### PR TITLE
Blueprints dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,4 +6,3 @@ description   := "A Java API for typed property graphs with a lot of angulillos"
 
 javaVersion         := "1.8"
 bucketSuffix        := "era7.com"
-libraryDependencies += "com.tinkerpop.blueprints" % "blueprints-core" % "2.5.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += "Era7 maven releases" at "https://s3-eu-west-1.amazonaws.com/releases.era7.com"
 
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.6.0")
+addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.7.0")

--- a/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
@@ -18,8 +18,8 @@ public interface TypedElementIndex <
   /* get the indexed property. */
   P property();
 
-  /* query this index using a Blueprints predicate */
-  Stream<E> query(com.tinkerpop.blueprints.Compare predicate, V value);
+  /* query this index by the property value */
+  Stream<E> query(V value);
 
   /* This interface declares that this index is over a property that uniquely classifies a element type for exact match queries; it adds the method `getTypedElement` for that. */
   public interface Unique <
@@ -38,12 +38,7 @@ public interface TypedElementIndex <
     /* get a element by providing a value of the indexed property. The default implementation relies on `query`. */
     default Optional<E> getElement(V byValue) {
 
-      Stream<E> strm = query (
-        com.tinkerpop.blueprints.Compare.EQUAL,
-        byValue
-      );
-
-      return strm.findFirst();
+      return query(byValue).findFirst();
     }
   }
 
@@ -64,10 +59,7 @@ public interface TypedElementIndex <
     /* get a list of elements by providing a value of the property. The default ... */
     default Stream<E> getElements(V byValue) {
 
-      return query(
-        com.tinkerpop.blueprints.Compare.EQUAL,
-        byValue
-      );
+      return query(byValue);
     }
   }
 }

--- a/src/main/java/com/bio4j/angulillos/TypedVertexQuery.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertexQuery.java
@@ -1,6 +1,6 @@
 package com.bio4j.angulillos;
 
-import com.tinkerpop.blueprints.Predicate;
+import java.util.function.BiPredicate;
 
 /*
   ## Vertex queries
@@ -41,7 +41,7 @@ interface VertexQueryOut <
     P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
     V
   >
-  Q has(P property, Predicate predicate, V value);
+  Q has(P property, BiPredicate<V,V> predicate, V value);
 
   <
     P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
@@ -105,7 +105,7 @@ interface VertexQueryIn <
     P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
     V
   >
-  Q has(P property, Predicate predicate, V value);
+  Q has(P property, BiPredicate<V,V> predicate, V value);
 
   <
     P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,


### PR DESCRIPTION
Is it really dependent on `blueprints-core` only for the `Predicate` and `Compare` types???