### PR TITLE
Add Compare enum for the index query

### DIFF
--- a/src/main/java/com/bio4j/angulillos/QueryPredicate.java
+++ b/src/main/java/com/bio4j/angulillos/QueryPredicate.java
@@ -1,0 +1,27 @@
+package com.bio4j.angulillos;
+
+public interface QueryPredicate {
+
+  /* This is the same as
+     - http://thinkaurelius.github.io/titan/javadoc/current/com/thinkaurelius/titan/core/attribute/Cmp.html
+     - http://tinkerpop.apache.org/javadocs/3.1.1-incubating/core/org/apache/tinkerpop/gremlin/process/traversal/Compare.html
+  */
+  public enum Compare implements QueryPredicate {
+    EQUAL,
+    GREATER_THAN,
+    GREATER_THAN_EQUAL,
+    LESS_THAN,
+    LESS_THAN_EQUAL,
+    NOT_EQUAL;
+  }
+
+  /* This is the same as
+     - http://thinkaurelius.github.io/titan/javadoc/current/com/thinkaurelius/titan/core/attribute/Contain.html
+     - http://tinkerpop.apache.org/javadocs/3.1.1-incubating/core/org/apache/tinkerpop/gremlin/process/traversal/Contains.html
+  */
+  public enum Contain implements QueryPredicate {
+    IN,
+    NOT_IN;
+  }
+
+}

--- a/src/main/java/com/bio4j/angulillos/TypedEdgeIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedEdgeIndex.java
@@ -5,8 +5,8 @@ import java.util.stream.Stream;
 
 public interface TypedEdgeIndex <
   // src
-  S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>, 
-  ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>, 
+  S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
+  ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
   SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
   // rel
   R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
@@ -25,12 +25,12 @@ extends
   TypedElementIndex<R,RT,P,V,RG,I,RV,RVT,RE,RET>
 {
 
-  RG graph();
+  default RT edgeType() { return elementType(); }
 
   public interface Unique <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>, 
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>, 
+    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
     SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
     // rel
     R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
@@ -44,8 +44,8 @@ extends
     T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
     TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
     TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  > 
-  extends 
+  >
+  extends
     TypedEdgeIndex<S,ST,SG, R,RT, P,V, RG,I,RV,RVT,RE,RET, T,TT,TG>,
     TypedElementIndex.Unique<R,RT, P,V, RG,I,RV,RVT,RE,RET>
   {
@@ -56,8 +56,8 @@ extends
 
   public interface List <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>, 
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>, 
+    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
     SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
     // rel
     R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
@@ -71,8 +71,8 @@ extends
     T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
     TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
     TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  > 
-  extends 
+  >
+  extends
     TypedEdgeIndex<S,ST,SG, R,RT,P,V, RG,I,RV,RVT,RE,RET, T,TT,TG>,
     TypedElementIndex.List<R,RT, P,V, RG,I,RV,RVT,RE,RET>
   {

--- a/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
@@ -19,35 +19,11 @@ public interface TypedElementIndex <
   /* Get the indexed property. */
   P property();
 
-  public interface QueryPredicate {}
-
-  /* This is an analog of
-     - http://thinkaurelius.github.io/titan/javadoc/current/com/thinkaurelius/titan/core/attribute/Cmp.html
-     - http://tinkerpop.apache.org/javadocs/3.1.1-incubating/core/org/apache/tinkerpop/gremlin/process/traversal/Compare.html
-  */
-  public enum ComparePredicate implements QueryPredicate {
-    EQUAL,
-    GREATER_THAN,
-    GREATER_THAN_EQUAL,
-    LESS_THAN,
-    LESS_THAN_EQUAL,
-    NOT_EQUAL;
-  }
-
   /* Query this index by comparing the property value with the given one */
-  Stream<E> compareQuery(ComparePredicate predicate, V value);
-
-  /* This is an analog of
-     - http://thinkaurelius.github.io/titan/javadoc/current/com/thinkaurelius/titan/core/attribute/Contain.html
-     - http://tinkerpop.apache.org/javadocs/3.1.1-incubating/core/org/apache/tinkerpop/gremlin/process/traversal/Contains.html
-  */
-  public enum ContainPredicate implements QueryPredicate {
-    IN,
-    NOT_IN;
-  }
+  Stream<E> query(QueryPredicate.Compare predicate, V value);
 
   /* Query this index by checking whether the property value is in/not in the given collection */
-  Stream<E> containQuery(ContainPredicate predicate, Collection<V> values);
+  Stream<E> query(QueryPredicate.Contain predicate, Collection<V> values);
 
 
   /* This interface declares that this index is over a property that uniquely classifies a element type for exact match queries; it adds the method `getTypedElement` for that. */
@@ -67,7 +43,7 @@ public interface TypedElementIndex <
     /* Get a element by providing a value of the indexed property */
     default Optional<E> getElement(V byValue) {
 
-      return compareQuery(ComparePredicate.EQUAL, byValue).findFirst();
+      return query(QueryPredicate.Compare.EQUAL, byValue).findFirst();
     }
   }
 
@@ -88,7 +64,7 @@ public interface TypedElementIndex <
     /* Get a list of elements by providing a value of the property */
     default Stream<E> getElements(V byValue) {
 
-      return compareQuery(ComparePredicate.EQUAL, byValue);
+      return query(QueryPredicate.Compare.EQUAL, byValue);
     }
   }
 }

--- a/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
@@ -16,8 +16,17 @@ public interface TypedElementIndex <
 >
 {
 
+  /* Index name */
+  String name();
+
+  /* The graph */
+  G graph();
+
   /* Get the indexed property. */
   P property();
+
+  default ET elementType() { return property().elementType(); }
+
 
   /* Query this index by comparing the property value with the given one */
   Stream<E> query(QueryPredicate.Compare predicate, V value);

--- a/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
@@ -18,8 +18,17 @@ public interface TypedElementIndex <
   /* get the indexed property. */
   P property();
 
+  public enum ComparePredicate {
+    EQUAL,
+    GREATER_THAN,
+    GREATER_THAN_EQUAL,
+    LESS_THAN,
+    LESS_THAN_EQUAL,
+    NOT_EQUAL;
+  }
+
   /* query this index by the property value */
-  Stream<E> query(V value);
+  Stream<E> query(ComparePredicate predicate, V value);
 
   /* This interface declares that this index is over a property that uniquely classifies a element type for exact match queries; it adds the method `getTypedElement` for that. */
   public interface Unique <
@@ -38,7 +47,7 @@ public interface TypedElementIndex <
     /* get a element by providing a value of the indexed property. The default implementation relies on `query`. */
     default Optional<E> getElement(V byValue) {
 
-      return query(byValue).findFirst();
+      return query(ComparePredicate.EQUAL, byValue).findFirst();
     }
   }
 
@@ -59,7 +68,7 @@ public interface TypedElementIndex <
     /* get a list of elements by providing a value of the property. The default ... */
     default Stream<E> getElements(V byValue) {
 
-      return query(byValue);
+      return query(ComparePredicate.EQUAL, byValue);
     }
   }
 }

--- a/src/main/java/com/bio4j/angulillos/TypedVertexIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertexIndex.java
@@ -20,7 +20,7 @@ extends
   TypedElementIndex<N,NT,P,V,G,I,RV,RVT,RE,RET>
 {
 
-  G graph();
+  default NT vertexType() { return elementType(); }
 
   /* This interface declares that this index is over a property that uniquely classifies a vertex type for exact match queries; it adds the method `getTypedVertex` for that.  */
   public interface Unique <
@@ -36,10 +36,7 @@ extends
   {
 
     /* get a vertex by providing a value of the indexed property. The default implementation relies on `query`. */
-    default Optional<N> getVertex(V byValue) {
-
-      return getElement(byValue);
-    }
+    default Optional<N> getVertex(V byValue) { return getElement(byValue); }
   }
 
   /* This interface declares that this index is over a property that classifies lists of vertices for exact match queries; it adds the method `getTypedVertexs` for that.  */
@@ -56,10 +53,7 @@ extends
   {
 
     /* get a list of vertices by providing a value of the property. The default */
-    default Stream<N> getVertices(V byValue) {
-
-      return getElements(byValue);
-    }
+    default Stream<N> getVertices(V byValue) { return getElements(byValue); }
   }
 
 }


### PR DESCRIPTION
In #36 it was removed from the `query` method. See https://github.com/bio4j/angulillos-titan/pull/17#issuecomment-196954920.

- Blueprints-2.5 _had_ [`Compare`](http://www.tinkerpop.com/docs/javadocs/blueprints/2.5.0/com/tinkerpop/blueprints/Compare.html) (which was used here)
- Tinkerpop-3.1 has [`Compare`](http://tinkerpop.apache.org/javadocs/3.1.1-incubating/core/org/apache/tinkerpop/gremlin/process/traversal/Compare.html)
- Titan-1.0 has [`Cmp`](http://thinkaurelius.github.io/titan/javadoc/current/com/thinkaurelius/titan/core/attribute/Cmp.html) 

which are all basically the same thing. I'm going to add here the same thing and in angulillos-titan convert it to the Titan's `Cmp`.