### PR TITLE
Fix RVT, RET types to Strings

### DIFF
--- a/src/main/java/com/bio4j/angulillos/Property.java
+++ b/src/main/java/com/bio4j/angulillos/Property.java
@@ -7,11 +7,11 @@ package com.bio4j.angulillos;
 */
 interface Property <
   // the element type
-  N extends TypedElement<N,NT,G,I,RV,RVT,RE,RET>, NT extends TypedElement.Type<N,NT,G,I,RV,RVT,RE,RET>,
+  N extends TypedElement<N,NT,G,I,RV,RE>, NT extends TypedElement.Type<N,NT,G,I,RV,RE>,
   // the property type and its value type
-  P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>, V,
+  P extends Property<N,NT,P,V,G,I,RV,RE>, V,
   // graph
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>, I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+  G extends TypedGraph<G,I,RV,RE>, I extends UntypedGraph<RV,RE>, RV,RE
 >
 {
 

--- a/src/main/java/com/bio4j/angulillos/TypedEdge.java
+++ b/src/main/java/com/bio4j/angulillos/TypedEdge.java
@@ -11,20 +11,20 @@ package com.bio4j.angulillos;
 */
 interface TypedEdge <
   // src
-  S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-  ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-  SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+  S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  SG extends TypedGraph<SG,I,RV,RE>,
   // rel
-  R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-  RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-  RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET,
+  R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+  RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+  RG extends TypedGraph<RG,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE,
   // tgt
-  T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-  TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-  TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+  T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  TG extends TypedGraph<TG,I,RV,RE>
 >
-  extends TypedElement<R,RT,RG,I,RV,RVT,RE,RET>
+  extends TypedElement<R,RT,RG,I,RV,RE>
 {
 
   /* `raw` gives you the raw edge underlying this instance; see [untyped graph](UntypedGraph.java.md) */
@@ -39,14 +39,14 @@ interface TypedEdge <
 
   @Override
   default <
-    P extends Property<R,RT,P,V,RG,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,RG,I,RV,RE>,
     V
   >
   V get(P property) { return graph().getProperty(self(), property); }
 
   @Override
   default <
-    P extends Property<R,RT,P,V,RG,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,RG,I,RV,RE>,
     V
   >
   R set(P property, V value) {
@@ -64,24 +64,22 @@ interface TypedEdge <
 
   interface Type <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET,
+    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   > extends
-    TypedElement.Type<R,RT,RG,I,RV,RVT,RE,RET>,
+    TypedElement.Type<R,RT,RG,I,RV,RE>,
     HasArity
   {
-    @Override
-    RET raw();
 
     ST sourceType();
     TT targetType();

--- a/src/main/java/com/bio4j/angulillos/TypedEdgeIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedEdgeIndex.java
@@ -5,49 +5,49 @@ import java.util.stream.Stream;
 
 interface TypedEdgeIndex <
   // src
-  S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-  ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-  SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+  S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  SG extends TypedGraph<SG,I,RV,RE>,
   // rel
-  R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-  RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
+  R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+  RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
   // property
-  P extends Property<R,RT,P,V,RG,I,RV,RVT,RE,RET>,
+  P extends Property<R,RT,P,V,RG,I,RV,RE>,
   V,
-  RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET,
+  RG extends TypedGraph<RG,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE,
   // tgt
-  T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-  TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-  TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+  T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  TG extends TypedGraph<TG,I,RV,RE>
 >
 extends
-  TypedElementIndex<R,RT,P,V,RG,I,RV,RVT,RE,RET>
+  TypedElementIndex<R,RT,P,V,RG,I,RV,RE>
 {
 
   default RT edgeType() { return elementType(); }
 
   interface Unique <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
+    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
     // property
-    P extends Property<R,RT,P,V,RG,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,RG,I,RV,RE>,
     V,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET,
+    RG extends TypedGraph<RG,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   extends
-    TypedEdgeIndex<S,ST,SG, R,RT, P,V, RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    TypedElementIndex.Unique<R,RT, P,V, RG,I,RV,RVT,RE,RET>
+    TypedEdgeIndex<S,ST,SG, R,RT, P,V, RG,I,RV,RE, T,TT,TG>,
+    TypedElementIndex.Unique<R,RT, P,V, RG,I,RV,RE>
   {
 
     /* get a node by providing a value of the indexed property. */
@@ -56,25 +56,25 @@ extends
 
   interface List <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
+    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
     // property
-    P extends Property<R,RT,P,V,RG,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,RG,I,RV,RE>,
     V,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET,
+    RG extends TypedGraph<RG,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   extends
-    TypedEdgeIndex<S,ST,SG, R,RT,P,V, RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    TypedElementIndex.List<R,RT, P,V, RG,I,RV,RVT,RE,RET>
+    TypedEdgeIndex<S,ST,SG, R,RT,P,V, RG,I,RV,RE, T,TT,TG>,
+    TypedElementIndex.List<R,RT, P,V, RG,I,RV,RE>
   {
 
     /* get a list of nodes by providing a value of the indexed property. */

--- a/src/main/java/com/bio4j/angulillos/TypedElement.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElement.java
@@ -14,10 +14,10 @@ package com.bio4j.angulillos;
   `E` refers to the element itself, and `ET` its type. You cannot define one without defining the other.
 */
 interface TypedElement <
-  E extends TypedElement<E,ET,G,I,RV,RVT,RE,RET>,
-  ET extends TypedElement.Type<E,ET,G,I,RV,RVT,RE,RET>,
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+  E extends TypedElement<E,ET,G,I,RV,RE>,
+  ET extends TypedElement.Type<E,ET,G,I,RV,RE>,
+  G extends TypedGraph<G,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE
 >
 {
 
@@ -35,14 +35,14 @@ interface TypedElement <
 
   /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
   <
-    P extends Property<E,ET,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<E,ET,P,V,G,I,RV,RE>,
     V
   >
   V get(P property);
 
   /* `set` sets the value of a `property` for this element. Again, you can only set properties that this element has, using values of the corresponding property value type. */
   <
-    P extends Property<E,ET,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<E,ET,P,V,G,I,RV,RE>,
     V
   >
   E set(P property, V value);
@@ -53,13 +53,11 @@ interface TypedElement <
     Element types are also used as factories for constructing instances of the corresponding elements.
   */
   interface Type <
-    E extends TypedElement<E,ET,G,I,RV,RVT,RE,RET>,
-    ET extends TypedElement.Type<E,ET,G,I,RV,RVT,RE,RET>,
-    G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+    E extends TypedElement<E,ET,G,I,RV,RE>,
+    ET extends TypedElement.Type<E,ET,G,I,RV,RE>,
+    G extends TypedGraph<G,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE
   > {
-    Object raw();
-
     default String name() { return getClass().getCanonicalName(); }
 
     G graph();

--- a/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElementIndex.java
@@ -6,13 +6,13 @@ import java.util.Collection;
 
 interface TypedElementIndex <
   // element
-  E extends TypedElement<E,ET,G,I,RV,RVT,RE,RET>,
-  ET extends TypedElement.Type<E,ET,G,I,RV,RVT,RE,RET>,
+  E extends TypedElement<E,ET,G,I,RV,RE>,
+  ET extends TypedElement.Type<E,ET,G,I,RV,RE>,
   // property
-  P extends Property<E,ET,P,V,G,I,RV,RVT,RE,RET>, V,
+  P extends Property<E,ET,P,V,G,I,RV,RE>, V,
   // graph
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+  G extends TypedGraph<G,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE
 >
 {
 
@@ -38,15 +38,15 @@ interface TypedElementIndex <
   /* This interface declares that this index is over a property that uniquely classifies a element type for exact match queries */
   interface Unique <
     // element
-    E extends TypedElement<E,ET,G,I,RV,RVT,RE,RET>,
-    ET extends TypedElement.Type<E,ET,G,I,RV,RVT,RE,RET>,
+    E extends TypedElement<E,ET,G,I,RV,RE>,
+    ET extends TypedElement.Type<E,ET,G,I,RV,RE>,
     // property
-    P extends Property<E,ET,P,V,G,I,RV,RVT,RE,RET>, V,
+    P extends Property<E,ET,P,V,G,I,RV,RE>, V,
     // graph
-    G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+    G extends TypedGraph<G,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE
   >
-    extends TypedElementIndex<E,ET, P,V, G, I,RV,RVT,RE,RET>
+    extends TypedElementIndex<E,ET, P,V, G, I,RV,RE>
   {
 
     /* Get an element by providing a value of the indexed property */
@@ -59,15 +59,15 @@ interface TypedElementIndex <
   /* This interface declares that this index is over a property that classifies lists of elements for exact match queries  */
   interface List <
     // element
-    E extends TypedElement<E,ET,G,I,RV,RVT,RE,RET>,
-    ET extends TypedElement.Type<E,ET,G,I,RV,RVT,RE,RET>,
+    E extends TypedElement<E,ET,G,I,RV,RE>,
+    ET extends TypedElement.Type<E,ET,G,I,RV,RE>,
     // property
-    P extends Property<E,ET,P,V,G,I,RV,RVT,RE,RET>, V,
+    P extends Property<E,ET,P,V,G,I,RV,RE>, V,
     // graph
-    G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+    G extends TypedGraph<G,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE
   >
-    extends TypedElementIndex<E,ET, P,V, G, I,RV,RVT,RE,RET>
+    extends TypedElementIndex<E,ET, P,V, G, I,RV,RE>
   {
 
     /* Get a list of elements by providing a value of the property */

--- a/src/main/java/com/bio4j/angulillos/TypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/TypedGraph.java
@@ -12,43 +12,43 @@ import java.util.Optional;
   A `TypedGraph` is, unsurprisingly, the typed version of [UntypedGraph](UntypedGraph.java.md).
 */
 interface TypedGraph <
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+  G extends TypedGraph<G,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE
 >
 {
 
   I raw();
 
   default <
-    V extends TypedVertex<V,VT,G,I,RV,RVT,RE,RET>,
-    VT extends TypedVertex.Type<V,VT,G,I,RV,RVT,RE,RET>
+    V extends TypedVertex<V,VT,G,I,RV,RE>,
+    VT extends TypedVertex.Type<V,VT,G,I,RV,RE>
   >
   V addVertex(VT vertexType) {
 
     return vertexType.vertex(
-      raw().addVertex( vertexType.raw() )
+      raw().addVertex( vertexType.name() )
     );
   }
 
   /* adds an edge; note that this method does not set any properties. As it needs to be called by vertices in possibly different graphs, all the graph bounds are free with respect to G. */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RVT,RE,RET,T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   R addEdge(S from, RT relType, T to) {
 
     return relType.edge(
-      raw().addEdge( from.raw(), relType.raw(), to.raw() )
+      raw().addEdge( from.raw(), relType.name(), to.raw() )
     );
   }
 
@@ -58,9 +58,9 @@ interface TypedGraph <
     These methods are used for setting and getting properties on vertices and edges.
   */
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+    P extends Property<N,NT,P,V,G,I,RV,RE>,
     V
   >
   V getProperty(N node, P property) {
@@ -71,17 +71,17 @@ interface TypedGraph <
   /* Get the value of a property from an edge of G. */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
+    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>,
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   V getProperty(R edge, P property) {
@@ -91,9 +91,9 @@ interface TypedGraph <
 
   /* Sets the value of a property for a vertex of G. */
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+    P extends Property<N,NT,P,V,G,I,RV,RE>,
     V
   >
   G setProperty(N node, P property, V value) {
@@ -105,17 +105,17 @@ interface TypedGraph <
   /* Sets the value of a property for an edge of G. */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
+    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>,
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   G setProperty(R edge, P property, V value) {
@@ -131,16 +131,16 @@ interface TypedGraph <
   */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
+    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   S source(R edge) {
 
@@ -151,16 +151,16 @@ interface TypedGraph <
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RVT,RE,RET,T,TT,TG>,
+    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   T target(R edge) {
 
@@ -178,61 +178,61 @@ interface TypedGraph <
     gets the out edges of a vertex N of G.
   */
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<R> outE(N node, RT relType) {
 
     return raw().outE(
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType::edge
     );
   }
 
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<T> outV(N node, RT relType) {
 
     return raw().outV (
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType.targetType()::vertex
     );
   }
 
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   R outOneE(N node, RT relType) {
 
@@ -240,54 +240,54 @@ interface TypedGraph <
     return relType.edge(
       raw().outE(
         node.raw(),
-        relType.raw()
+        relType.name()
       )
       .findFirst().get()
     );
   }
 
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   T outOneV(N node, RT relType) {
 
     return relType.targetType().vertex(
       raw().outV(
         node.raw(),
-        relType.raw()
+        relType.name()
       )
       .findFirst().get()
     );
   }
 
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Optional<R> outOptionalE(N node, RT relType) {
 
     return raw().outE(
       node.raw(),
-      relType.raw()
+      relType.name()
     )
     .findFirst()
     .map(
@@ -295,23 +295,23 @@ interface TypedGraph <
     );
   }
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Optional<T> outOptionalV(N node, RT relType) {
 
     return raw().outV(
       node.raw(),
-      relType.raw()
+      relType.name()
     )
     .findFirst()
     .map(
@@ -320,45 +320,45 @@ interface TypedGraph <
   }
 
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<R> outManyE(N node, RT relType) {
 
     return raw().outE(
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType::edge
     );
   }
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<T> outManyV(N node, RT relType) {
 
     return raw().outV(
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType.targetType()::vertex
     );
@@ -369,44 +369,44 @@ interface TypedGraph <
   */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   Stream<R> inE(RT relType, N node) {
 
     return raw().inE(
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType::edge
     );
   }
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   Stream<S> inV(RT relType, N node) {
 
     return raw().inV(
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType.sourceType()::vertex
     );
@@ -414,48 +414,48 @@ interface TypedGraph <
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   R inOneE(RT relType, N node) {
 
     return relType.edge(
       raw().inE(
         node.raw(),
-        relType.raw()
+        relType.name()
       )
       .findFirst().get()
     );
   }
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   S inOneV(RT relType, N node) {
 
     return relType.sourceType().vertex(
       raw().inV(
         node.raw(),
-        relType.raw()
+        relType.name()
       )
       .findFirst().get()
     );
@@ -463,23 +463,23 @@ interface TypedGraph <
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   Optional<R> inOptionalE(RT relType, N node) {
 
     return raw().inE(
       node.raw(),
-      relType.raw()
+      relType.name()
     )
     .findFirst()
     .map(
@@ -488,23 +488,23 @@ interface TypedGraph <
   }
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   Optional<S> inOptionalV(RT relType, N node) {
 
     return raw().inV(
       node.raw(),
-      relType.raw()
+      relType.name()
     )
     .findFirst()
     .map(
@@ -514,46 +514,46 @@ interface TypedGraph <
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   Stream<R> inManyE(RT relType, N node) {
 
     return raw().inE(
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType::edge
     );
   }
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
   >
   Stream<S> inManyV(RT relType, N node) {
 
     return raw().inV(
       node.raw(),
-      relType.raw()
+      relType.name()
     ).map(
       relType.sourceType()::vertex
     );

--- a/src/main/java/com/bio4j/angulillos/TypedVertex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertex.java
@@ -10,12 +10,12 @@ import java.util.stream.Stream;
   A typed vertex. A vertex and its type need to be defined at the same time. The vertex keeps a reference of its type, while the type works as a factory for creating vertices with that type.
 */
 interface TypedVertex <
-  N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-  NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+  N extends TypedVertex<N,NT,G,I,RV,RE>,
+  NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  G extends TypedGraph<G,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE
 >
-  extends TypedElement<N,NT,G,I,RV,RVT,RE,RET>
+  extends TypedElement<N,NT,G,I,RV,RE>
 {
 
   @Override
@@ -27,25 +27,25 @@ interface TypedVertex <
     There are two methods for creating new relationships, into and out of this node respectively. Their implementation delegates to the graph methods.
   */
   default <
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   R addInEdge(S from, RT relType) { return graph().addEdge( from, relType, self() ); }
 
 
   default <
     // rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   R addOutEdge(RT relType, T to) { return graph().addEdge( self(), relType, to ); }
 
@@ -53,7 +53,7 @@ interface TypedVertex <
   /* ### Properties */
   @Override
   default <
-    P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<N,NT,P,V,G,I,RV,RE>,
     V
   >
   V get(P property) { return graph().getProperty(self(), property); }
@@ -61,7 +61,7 @@ interface TypedVertex <
 
   @Override
   default <
-    P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<N,NT,P,V,G,I,RV,RE>,
     V
   >
   N set(P property, V value) {
@@ -77,26 +77,26 @@ interface TypedVertex <
   */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   Stream<R> inE(RT relType) { return graph().inE( relType, self() ); }
 
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   Stream<S> inV(RT relType) { return graph().inV( relType, self() ); }
 
@@ -104,208 +104,206 @@ interface TypedVertex <
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   R inOneE(RT relType) { return graph().inOneE( relType, self() ); }
 
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   S inOneV(RT relType) { return graph().inOneV( relType, self() ); }
 
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   Optional<R> inOptionalE(RT relType) { return graph().inOptionalE( relType, self() ); }
 
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   Optional<S> inOptionalV(RT relType) { return graph().inOptionalV( relType, self() ); }
 
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   Stream<R> inManyE(RT relType) { return graph().inManyE( relType, self() ); }
 
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
+    S extends TypedVertex<S,ST,SG,I,RV,RE>,
+    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+    SG extends TypedGraph<SG,I,RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
+    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
       TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
+    RG extends TypedGraph<RG,I,RV,RE>
   >
   Stream<S> inManyV(RT relType) { return graph().inManyV( relType, self() ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<R> outE(RT relType) { return graph().outE( self(), relType ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<T> outV(RT relType) { return graph().outV( self(), relType ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<R> outManyE(RT relType) { return graph().outManyE( self(), relType ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Stream<T> outManyV(RT relType) { return graph().outManyV( self(), relType ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   T outOneV(RT relType) { return graph().outOneV( self(), relType ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   R outOneE(RT relType) { return graph().outOneE( self(), relType ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Optional<R> outOptionalE(RT relType) { return graph().outOptionalE( self(), relType ); }
 
 
   default <
     //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
       TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    RG extends TypedGraph<RG,I,RV,RE>,
     // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+    T extends TypedVertex<T,TT,TG,I,RV,RE>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+    TG extends TypedGraph<TG,I,RV,RE>
   >
   Optional<T> outOptionalV(RT relType) { return graph().outOptionalV( self(), relType ); }
 
 
   interface Type <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+    G extends TypedGraph<G,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE
   > extends
-    TypedElement.Type<N,NT,G,I,RV,RVT,RE,RET>
+    TypedElement.Type<N,NT,G,I,RV,RE>
   {
-    @Override
-    RVT raw();
 
     /* Constructs a value of the typed vertex of this type */
     N vertex(RV rawVertex);

--- a/src/main/java/com/bio4j/angulillos/TypedVertexIndex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertexIndex.java
@@ -10,29 +10,29 @@ import java.util.Optional;
   A vertex index indexes vertices of a given type through values of one of its properties. This just adds a bound on the indexed type to be a TypedVertex; see `TypedElementIndex`
 */
 interface TypedVertexIndex <
-  N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-  NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-  P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>, V,
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+  N extends TypedVertex<N,NT,G,I,RV,RE>,
+  NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  P extends Property<N,NT,P,V,G,I,RV,RE>, V,
+  G extends TypedGraph<G,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE
 >
 extends
-  TypedElementIndex<N,NT,P,V,G,I,RV,RVT,RE,RET>
+  TypedElementIndex<N,NT,P,V,G,I,RV,RE>
 {
 
   default NT vertexType() { return elementType(); }
 
   /* This interface declares that this index is over a property that uniquely classifies a vertex type for exact match queries; it adds the method `getTypedVertex` for that.  */
   interface Unique <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>, V,
-    G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+    P extends Property<N,NT,P,V,G,I,RV,RE>, V,
+    G extends TypedGraph<G,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE
   >
   extends
-    TypedVertexIndex<N,NT,P,V,G,I,RV,RVT,RE,RET>,
-    TypedElementIndex.Unique<N,NT,P,V,G,I,RV,RVT,RE,RET>
+    TypedVertexIndex<N,NT,P,V,G,I,RV,RE>,
+    TypedElementIndex.Unique<N,NT,P,V,G,I,RV,RE>
   {
 
     /* get a vertex by providing a value of the indexed property. The default implementation relies on `query`. */
@@ -41,15 +41,15 @@ extends
 
   /* This interface declares that this index is over a property that classifies lists of vertices for exact match queries; it adds the method `getTypedVertexs` for that.  */
   interface List <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    P extends Property<N,NT,P,V,G,I,RV,RVT,RE,RET>, V,
-    G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-    I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT, RE,RET
+    N extends TypedVertex<N,NT,G,I,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+    P extends Property<N,NT,P,V,G,I,RV,RE>, V,
+    G extends TypedGraph<G,I,RV,RE>,
+    I extends UntypedGraph<RV,RE>, RV,RE
   >
   extends
-    TypedVertexIndex<N,NT,P,V,G,I,RV,RVT,RE,RET>,
-    TypedElementIndex.List<N,NT,P,V,G,I,RV,RVT,RE,RET>
+    TypedVertexIndex<N,NT,P,V,G,I,RV,RE>,
+    TypedElementIndex.List<N,NT,P,V,G,I,RV,RE>
   {
 
     /* get a list of vertices by providing a value of the property. The default */

--- a/src/main/java/com/bio4j/angulillos/TypedVertexQuery.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertexQuery.java
@@ -9,60 +9,60 @@ import java.util.function.BiPredicate;
 */
 interface VertexQueryOut <
   // vertex
-  N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-  NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+  N extends TypedVertex<N,NT,G,I,RV,RE>,
+  NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
   // edge
-  R extends TypedEdge<N,NT,G, R,RT,G,I,RV,RVT,RE,RET, T,TT,G>,
-  RT extends TypedEdge.Type<N,NT,G, R,RT,G,I,RV,RVT,RE,RET, T,TT,G>,
+  R extends TypedEdge<N,NT,G, R,RT,G,I,RV,RE, T,TT,G>,
+  RT extends TypedEdge.Type<N,NT,G, R,RT,G,I,RV,RE, T,TT,G>,
   // target vertices
-  T extends TypedVertex<T,TT,G,I,RV,RVT,RE,RET>,
-  TT extends TypedVertex.Type<T,TT,G,I,RV,RVT,RE,RET>,
+  T extends TypedVertex<T,TT,G,I,RV,RE>,
+  TT extends TypedVertex.Type<T,TT,G,I,RV,RE>,
   // the query
-  Q extends VertexQueryOut<N,NT, R,RT, T,TT, Q, G,I,RV,RVT,RE,RET>,
+  Q extends VertexQueryOut<N,NT, R,RT, T,TT, Q, G,I,RV,RE>,
   // graph
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT,RE,RET
+  G extends TypedGraph<G,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE
 >
 {
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q has(P property);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q has(P property, V value);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q has(P property, BiPredicate<V,V> predicate, V value);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q hasNot(P property);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q hasNot(P property, V value);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V extends Comparable<?>
   >
   Q interval(P property, V startValue, V endValue);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q limit(int limit);
@@ -73,61 +73,61 @@ interface VertexQueryOut <
 
 interface VertexQueryIn <
   // source vertices
-  S extends TypedVertex<S,ST,G,I,RV,RVT,RE,RET>,
-  ST extends TypedVertex.Type<S,ST,G,I,RV,RVT,RE,RET>,
+  S extends TypedVertex<S,ST,G,I,RV,RE>,
+  ST extends TypedVertex.Type<S,ST,G,I,RV,RE>,
   // edge
-  R extends TypedEdge<S,ST,G, R,RT,G,I,RV,RVT,RE,RET, N,NT,G>,
-  RT extends TypedEdge.Type<S,ST,G, R,RT,G,I,RV,RVT,RE,RET, N,NT,G>,
+  R extends TypedEdge<S,ST,G, R,RT,G,I,RV,RE, N,NT,G>,
+  RT extends TypedEdge.Type<S,ST,G, R,RT,G,I,RV,RE, N,NT,G>,
   // vertex
-  N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-  NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+  N extends TypedVertex<N,NT,G,I,RV,RE>,
+  NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
   // the query
-  Q extends VertexQueryIn<S,ST, R,RT, N,NT, Q, G,I,RV,RVT,RE,RET>,
+  Q extends VertexQueryIn<S,ST, R,RT, N,NT, Q, G,I,RV,RE>,
   // graph
-  G extends TypedGraph<G,I,RV,RVT,RE,RET>,
-  I extends UntypedGraph<RV,RVT,RE,RET>, RV,RVT,RE,RET
+  G extends TypedGraph<G,I,RV,RE>,
+  I extends UntypedGraph<RV,RE>, RV,RE
 >
 {
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q has(P property);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q has(P property, V value);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   // FIXME: predicate should be of the type QueryPredicate
   Q has(P property, BiPredicate<V,V> predicate, V value);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q hasNot(P property);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q hasNot(P property, V value);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V extends Comparable<?>
   >
   Q interval(P property, V startValue, V endValue);
 
   <
-    P extends Property<R,RT,P,V,G,I,RV,RVT,RE,RET>,
+    P extends Property<R,RT,P,V,G,I,RV,RE>,
     V
   >
   Q limit(int limit);

--- a/src/main/java/com/bio4j/angulillos/UntypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/UntypedGraph.java
@@ -11,13 +11,11 @@ import java.util.stream.Stream;
   With respect to the type parameters, they represent the vertex and edge types used by this particular untyped graph. The four parameters are:
 
   - `RV` for **R**aw **V**ertex, the raw type used for vertices (like `TitanVertex`, `Node` in Neo4j, etc)
-  - `RVT` for **R**aw **V**ertex **T**ype, the raw type used for vertex types (`String`s, `Label` in Neo4j, etc)
   - `RE` for **R**aw **E**dge, the raw type used for edge (like `TitanEdge`, `Relationship` in Neo4j)
-  - `RET` for **R**aw **E**dge **T**ype, the raw type used for edge types (like `EdgeLabel`, or `Label` in Neo4j)
 
   Properties are represented using `String`s. What the methods are supposed to do is I think pretty obvious from their names; there is anyway a short explanation for each.
 */
-interface UntypedGraph<RV,RVT,RE,RET> {
+interface UntypedGraph<RV,RE> {
 
   /* #### Methods on vertices */
 
@@ -27,14 +25,14 @@ interface UntypedGraph<RV,RVT,RE,RET> {
   <V> RV setPropertyV(RV vertex, String property, V value);
 
   /* - Get the edges of type `edgeType` _out_ of `vertex` */
-  Stream<RE> outE(RV vertex, RET edgeType);
+  Stream<RE> outE(RV vertex, String edgeLabel);
   /* - Get the _target_ vertices of the edges of type `edgeType` _out_ of `vertex` */
-  Stream<RV> outV(RV vertex, RET edgeType);
+  Stream<RV> outV(RV vertex, String edgeLabel);
 
   /* - Get the edges of type `edgeType` _into_ `vertex` */
-  Stream<RE> inE(RV vertex, RET edgeType);
+  Stream<RE> inE(RV vertex, String edgeLabel);
   /* - Get the _source_ vertices of the edges of type `edgeType` _into_ `vertex` */
-  Stream<RV> inV(RV vertex, RET edgeType);
+  Stream<RV> inV(RV vertex, String edgeLabel);
 
 
   /* #### Methods on edges */
@@ -52,10 +50,10 @@ interface UntypedGraph<RV,RVT,RE,RET> {
 
   /* #### Create vertices and edges */
 
-  /* - Returns a new edge of type `edgeType`, having source `from` and target `to` */
-  RE addEdge(RV from, RET edgeType, RV to);
+  /* - Returns a new edge: source -[edgeLabel]-> target */
+  RE addEdge(RV source, String edgeLabel, RV target);
   /* - Returns a new vertex of type `vertexType` */
-  RV addVertex(RVT vertexType);
+  RV addVertex(String vertexLabel);
 
 
   /* These two methods are here at this level just for convenience;

--- a/src/test/java/com/bio4j/angulillos/TwitterGraph.java
+++ b/src/test/java/com/bio4j/angulillos/TwitterGraph.java
@@ -3,14 +3,13 @@ package com.bio4j.angulillos;
 import com.bio4j.angulillos.TypedEdge.Type.*;
 
 public abstract class TwitterGraph <
-  I extends UntypedGraph<RV,RVT, RE,RET>,
-  RV, RVT,
-  RE, RET
+  I extends UntypedGraph<RV,RE>,
+  RV,RE
 >
 implements
   TypedGraph<
-    TwitterGraph<I,RV,RVT,RE,RET>,
-    I, RV,RVT, RE,RET
+    TwitterGraph<I,RV,RE>,
+    I, RV,RE
   >
 {
 
@@ -19,12 +18,12 @@ implements
   @Override public I raw() { return rawGraph; }
 
   // vertices
-  public abstract TwitterGraph<I,RV,RVT,RE,RET>.UserType        User();
-  public abstract TwitterGraph<I,RV,RVT,RE,RET>.TweetType       Tweet();
+  public abstract TwitterGraph<I,RV,RE>.UserType        User();
+  public abstract TwitterGraph<I,RV,RE>.TweetType       Tweet();
   // edges
-  public abstract TwitterGraph<I,RV,RVT,RE,RET>.PostedType      Posted();
-  public abstract TwitterGraph<I,RV,RVT,RE,RET>.RepliesToType   RepliesTo();
-  public abstract TwitterGraph<I,RV,RVT,RE,RET>.FollowsType     Follows();
+  public abstract TwitterGraph<I,RV,RE>.PostedType      Posted();
+  public abstract TwitterGraph<I,RV,RE>.RepliesToType   RepliesTo();
+  public abstract TwitterGraph<I,RV,RE>.FollowsType     Follows();
 
   /* ### Vertices and their types
   */
@@ -33,8 +32,8 @@ implements
   public final class UserType
   extends
     VertexType<
-      TwitterGraph<I,RV,RVT,RE,RET>.User,
-      TwitterGraph<I,RV,RVT,RE,RET>.UserType
+      TwitterGraph<I,RV,RE>.User,
+      TwitterGraph<I,RV,RE>.UserType
     >
   {
     public UserType(RVT raw) { super(raw); }
@@ -58,8 +57,8 @@ implements
   public final class User
   extends
     Vertex<
-      TwitterGraph<I,RV,RVT,RE,RET>.User,
-      TwitterGraph<I,RV,RVT,RE,RET>.UserType
+      TwitterGraph<I,RV,RE>.User,
+      TwitterGraph<I,RV,RE>.UserType
     >
   {
     public User(RV vertex, UserType type) { super(vertex, type); }
@@ -71,8 +70,8 @@ implements
   public final class TweetType
   extends
     VertexType<
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,
-      TwitterGraph<I,RV,RVT,RE,RET>.TweetType
+      TwitterGraph<I,RV,RE>.Tweet,
+      TwitterGraph<I,RV,RE>.TweetType
     >
   {
     public TweetType(RVT raw) { super(raw); }
@@ -96,8 +95,8 @@ implements
   public final class Tweet
   extends
     Vertex<
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,
-      TwitterGraph<I,RV,RVT,RE,RET>.TweetType
+      TwitterGraph<I,RV,RE>.Tweet,
+      TwitterGraph<I,RV,RE>.TweetType
     >
   {
     public Tweet(RV vertex, TweetType type) { super(vertex, type); }
@@ -110,9 +109,9 @@ implements
   public final class PostedType
   extends
     EdgeType<
-      TwitterGraph<I,RV,RVT,RE,RET>.User,TwitterGraph<I,RV,RVT,RE,RET>.UserType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Posted,TwitterGraph<I,RV,RVT,RE,RET>.PostedType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,TwitterGraph<I,RV,RVT,RE,RET>.TweetType
+      TwitterGraph<I,RV,RE>.User,TwitterGraph<I,RV,RE>.UserType,
+      TwitterGraph<I,RV,RE>.Posted,TwitterGraph<I,RV,RE>.PostedType,
+      TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType
     >
   implements
     // u -[posted]-> t
@@ -127,9 +126,9 @@ implements
   public final class Posted
   extends
     Edge<
-      TwitterGraph<I,RV,RVT,RE,RET>.User,TwitterGraph<I,RV,RVT,RE,RET>.UserType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Posted,TwitterGraph<I,RV,RVT,RE,RET>.PostedType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,TwitterGraph<I,RV,RVT,RE,RET>.TweetType
+      TwitterGraph<I,RV,RE>.User,TwitterGraph<I,RV,RE>.UserType,
+      TwitterGraph<I,RV,RE>.Posted,TwitterGraph<I,RV,RE>.PostedType,
+      TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType
     >
   {
     public Posted(RE edge, PostedType type) { super(edge, type); }
@@ -139,9 +138,9 @@ implements
   public final class FollowsType
   extends
     EdgeType<
-      TwitterGraph<I,RV,RVT,RE,RET>.User,TwitterGraph<I,RV,RVT,RE,RET>.UserType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Follows,TwitterGraph<I,RV,RVT,RE,RET>.FollowsType,
-      TwitterGraph<I,RV,RVT,RE,RET>.User,TwitterGraph<I,RV,RVT,RE,RET>.UserType
+      TwitterGraph<I,RV,RE>.User,TwitterGraph<I,RV,RE>.UserType,
+      TwitterGraph<I,RV,RE>.Follows,TwitterGraph<I,RV,RE>.FollowsType,
+      TwitterGraph<I,RV,RE>.User,TwitterGraph<I,RV,RE>.UserType
     >
   implements
     AnyToAny
@@ -153,9 +152,9 @@ implements
   public final class Follows
   extends
     Edge<
-      TwitterGraph<I,RV,RVT,RE,RET>.User,TwitterGraph<I,RV,RVT,RE,RET>.UserType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Follows,TwitterGraph<I,RV,RVT,RE,RET>.FollowsType,
-      TwitterGraph<I,RV,RVT,RE,RET>.User,TwitterGraph<I,RV,RVT,RE,RET>.UserType
+      TwitterGraph<I,RV,RE>.User,TwitterGraph<I,RV,RE>.UserType,
+      TwitterGraph<I,RV,RE>.Follows,TwitterGraph<I,RV,RE>.FollowsType,
+      TwitterGraph<I,RV,RE>.User,TwitterGraph<I,RV,RE>.UserType
     >
   {
     public Follows(RE edge, FollowsType type) { super(edge, type); }
@@ -165,9 +164,9 @@ implements
   public final class RepliesToType
   extends
     EdgeType<
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,TwitterGraph<I,RV,RVT,RE,RET>.TweetType,
-      TwitterGraph<I,RV,RVT,RE,RET>.RepliesTo,TwitterGraph<I,RV,RVT,RE,RET>.RepliesToType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,TwitterGraph<I,RV,RVT,RE,RET>.TweetType
+      TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType,
+      TwitterGraph<I,RV,RE>.RepliesTo,TwitterGraph<I,RV,RE>.RepliesToType,
+      TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType
     >
   implements
     // a tweet can be a reply to at most one tweet
@@ -180,9 +179,9 @@ implements
   public final class RepliesTo
   extends
     Edge<
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,TwitterGraph<I,RV,RVT,RE,RET>.TweetType,
-      TwitterGraph<I,RV,RVT,RE,RET>.RepliesTo,TwitterGraph<I,RV,RVT,RE,RET>.RepliesToType,
-      TwitterGraph<I,RV,RVT,RE,RET>.Tweet,TwitterGraph<I,RV,RVT,RE,RET>.TweetType
+      TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType,
+      TwitterGraph<I,RV,RE>.RepliesTo,TwitterGraph<I,RV,RE>.RepliesToType,
+      TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType
     >
   {
     public RepliesTo(RE edge, RepliesToType type) { super(edge, type); }
@@ -211,33 +210,33 @@ implements
   */
 
   public abstract class ElementType<
-    E extends TwitterGraph<I, RV, RVT, RE, RET>.Element<E, ET>,
-    ET extends TwitterGraph<I, RV, RVT, RE, RET>.ElementType<E, ET>
+    E extends TwitterGraph<I, RV,RE>.Element<E, ET>,
+    ET extends TwitterGraph<I, RV,RE>.ElementType<E, ET>
   >
   implements
-    TypedElement.Type<E,ET,TwitterGraph<I,RV,RVT,RE,RET>, I, RV, RVT, RE, RET>
+    TypedElement.Type<E,ET,TwitterGraph<I,RV,RE>, I, RV,RE>
   {
-    @Override public final TwitterGraph<I,RV,RVT,RE,RET> graph() { return TwitterGraph.this; }
+    @Override public final TwitterGraph<I,RV,RE> graph() { return TwitterGraph.this; }
   }
 
   public abstract class Element<
-    E extends TwitterGraph<I, RV, RVT, RE, RET>.Element<E,ET>,
-    ET extends TwitterGraph<I, RV, RVT, RE, RET>.ElementType<E,ET>
+    E extends TwitterGraph<I, RV,RE>.Element<E,ET>,
+    ET extends TwitterGraph<I, RV,RE>.ElementType<E,ET>
   >
   implements
-    TypedElement<E,ET,TwitterGraph<I, RV, RVT, RE, RET>, I, RV, RVT, RE, RET>
+    TypedElement<E,ET,TwitterGraph<I, RV,RE>, I, RV,RE>
   {
-    @Override public final TwitterGraph<I, RV, RVT, RE, RET> graph() { return TwitterGraph.this; }
+    @Override public final TwitterGraph<I, RV,RE> graph() { return TwitterGraph.this; }
   }
 
   public abstract class VertexType<
-    V extends TwitterGraph<I, RV, RVT, RE, RET>.Vertex<V,VT>,
-    VT extends TwitterGraph<I, RV, RVT, RE, RET>.VertexType<V,VT>
+    V extends TwitterGraph<I, RV,RE>.Vertex<V,VT>,
+    VT extends TwitterGraph<I, RV,RE>.VertexType<V,VT>
   >
   extends
-    TwitterGraph<I,RV,RVT,RE,RET>.ElementType<V,VT>
+    TwitterGraph<I,RV,RE>.ElementType<V,VT>
   implements
-    com.bio4j.angulillos.TypedVertex.Type<V,VT,TwitterGraph<I, RV, RVT, RE, RET>, I,RV,RVT,RE,RET>
+    com.bio4j.angulillos.TypedVertex.Type<V,VT,TwitterGraph<I, RV,RE>, I,RV,RE>
   {
     private final RVT raw;
     protected VertexType(RVT type) { this.raw = type; }
@@ -245,13 +244,13 @@ implements
   }
 
   public abstract class Vertex<
-    V extends TwitterGraph<I, RV, RVT, RE, RET>.Vertex<V,VT>,
-    VT extends TwitterGraph<I, RV, RVT, RE, RET>.VertexType<V,VT>
+    V extends TwitterGraph<I, RV,RE>.Vertex<V,VT>,
+    VT extends TwitterGraph<I, RV,RE>.VertexType<V,VT>
   >
   extends
-    TwitterGraph<I,RV,RVT,RE,RET>.Element<V,VT>
+    TwitterGraph<I,RV,RE>.Element<V,VT>
   implements
-    com.bio4j.angulillos.TypedVertex<V,VT,TwitterGraph<I, RV, RVT, RE, RET>, I,RV,RVT,RE,RET>
+    com.bio4j.angulillos.TypedVertex<V,VT,TwitterGraph<I, RV,RE>, I,RV,RE>
   {
     private final RV raw;
     private final VT type;
@@ -264,20 +263,20 @@ implements
   }
 
   public abstract class EdgeType<
-    S extends TwitterGraph<I, RV, RVT, RE, RET>.Vertex<S,ST>,
-    ST extends TwitterGraph<I, RV, RVT, RE, RET>.VertexType<S,ST>,
-    E extends TwitterGraph<I, RV, RVT, RE, RET>.Edge<S,ST,E,ET,T,TT>,
-    ET extends TwitterGraph<I, RV, RVT, RE, RET>.EdgeType<S,ST,E,ET,T,TT>,
-    T extends TwitterGraph<I, RV, RVT, RE, RET>.Vertex<T,TT>,
-    TT extends TwitterGraph<I, RV, RVT, RE, RET>.VertexType<T,TT>
+    S extends TwitterGraph<I, RV,RE>.Vertex<S,ST>,
+    ST extends TwitterGraph<I, RV,RE>.VertexType<S,ST>,
+    E extends TwitterGraph<I, RV,RE>.Edge<S,ST,E,ET,T,TT>,
+    ET extends TwitterGraph<I, RV,RE>.EdgeType<S,ST,E,ET,T,TT>,
+    T extends TwitterGraph<I, RV,RE>.Vertex<T,TT>,
+    TT extends TwitterGraph<I, RV,RE>.VertexType<T,TT>
   >
   extends
-    TwitterGraph<I,RV,RVT,RE,RET>.ElementType<E,ET>
+    TwitterGraph<I,RV,RE>.ElementType<E,ET>
   implements
     com.bio4j.angulillos.TypedEdge.Type<
-      S, ST, TwitterGraph<I, RV, RVT, RE, RET>,
-      E, ET, TwitterGraph<I, RV, RVT, RE, RET>, I, RV, RVT, RE, RET,
-      T, TT, TwitterGraph<I, RV, RVT, RE, RET>
+      S, ST, TwitterGraph<I, RV,RE>,
+      E, ET, TwitterGraph<I, RV,RE>, I, RV,RE,
+      T, TT, TwitterGraph<I, RV,RE>
     >
   {
     private final RET raw;
@@ -294,20 +293,20 @@ implements
   }
 
   public abstract class Edge<
-    S extends TwitterGraph<I, RV, RVT, RE, RET>.Vertex<S,ST>,
-    ST extends TwitterGraph<I, RV, RVT, RE, RET>.VertexType<S,ST>,
-    E extends TwitterGraph<I, RV, RVT, RE, RET>.Edge<S,ST,E,ET,T,TT>,
-    ET extends TwitterGraph<I, RV, RVT, RE, RET>.EdgeType<S,ST,E,ET,T,TT>,
-    T extends TwitterGraph<I, RV, RVT, RE, RET>.Vertex<T,TT>,
-    TT extends TwitterGraph<I, RV, RVT, RE, RET>.VertexType<T,TT>
+    S extends TwitterGraph<I, RV,RE>.Vertex<S,ST>,
+    ST extends TwitterGraph<I, RV,RE>.VertexType<S,ST>,
+    E extends TwitterGraph<I, RV,RE>.Edge<S,ST,E,ET,T,TT>,
+    ET extends TwitterGraph<I, RV,RE>.EdgeType<S,ST,E,ET,T,TT>,
+    T extends TwitterGraph<I, RV,RE>.Vertex<T,TT>,
+    TT extends TwitterGraph<I, RV,RE>.VertexType<T,TT>
   >
   extends
-    TwitterGraph<I,RV,RVT,RE,RET>.Element<E,ET>
+    TwitterGraph<I,RV,RE>.Element<E,ET>
   implements
     com.bio4j.angulillos.TypedEdge<
-      S, ST, TwitterGraph<I, RV, RVT, RE, RET>,
-      E, ET, TwitterGraph<I, RV, RVT, RE, RET>, I, RV, RVT, RE, RET,
-      T, TT, TwitterGraph<I, RV, RVT, RE, RET>
+      S, ST, TwitterGraph<I, RV,RE>,
+      E, ET, TwitterGraph<I, RV,RE>, I, RV,RE,
+      T, TT, TwitterGraph<I, RV,RE>
     >
   {
     private final RE edge;
@@ -321,13 +320,13 @@ implements
   }
 
   public abstract class Property<
-    V extends TwitterGraph<I,RV, RVT, RE, RET>.Element<V,VT>,
-    VT extends TwitterGraph<I,RV,RVT, RE, RET>.ElementType<V, VT>,
-    P extends TwitterGraph<I,RV,RVT, RE, RET>.Property<V,VT,P,PV>,
+    V extends TwitterGraph<I,RV,RE>.Element<V,VT>,
+    VT extends TwitterGraph<I,RV,RE>.ElementType<V, VT>,
+    P extends TwitterGraph<I,RV,RE>.Property<V,VT,P,PV>,
     PV
   >
   implements
-    com.bio4j.angulillos.Property<V,VT,P,PV,TwitterGraph<I, RV, RVT, RE, RET>, I, RV, RVT, RE, RET>
+    com.bio4j.angulillos.Property<V,VT,P,PV,TwitterGraph<I, RV,RE>, I, RV,RE>
   {
     private final VT type;
     protected Property(VT type) { this.type = type; }


### PR DESCRIPTION
To `String`s, because in any DB any kind of keys/labels have `String` representation and it's enough for all manipulations with graph element types in angulillos.

@eparejatobes right?