### PR TITLE
Remove duplicated in/out-...-E/V methods from the TypedGraph

### DIFF
--- a/src/main/java/com/bio4j/angulillos/TypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/TypedGraph.java
@@ -124,10 +124,9 @@ interface TypedGraph <
     return edge.graph();
   }
 
-  /*
-    ### source and target
+  /* ### Source and target
 
-    gets the source of an edge of G, which could be of a different graph.
+    Gets the source of an edge of G, which could be of a different graph.
   */
   default <
     // src
@@ -170,203 +169,9 @@ interface TypedGraph <
   }
 
 
-  /* ### Incident edges from vertices */
+  /* ### Incident edges/vertices from vertices */
 
-  /*
-    #### out methods
-
-    gets the out edges of a vertex N of G.
-  */
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Stream<R> outE(N node, RT relType) {
-
-    return raw().outE(
-      node.raw(),
-      relType.raw()
-    ).map(
-      relType::edge
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Stream<T> outV(N node, RT relType) {
-
-    return raw().outV (
-      node.raw(),
-      relType.raw()
-    ).map(
-      relType.targetType()::vertex
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  R outOneE(N node, RT relType) {
-
-    // we know it has one!
-    return relType.edge(
-      raw().outE(
-        node.raw(),
-        relType.raw()
-      )
-      .findFirst().get()
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  T outOneV(N node, RT relType) {
-
-    return relType.targetType().vertex(
-      raw().outV(
-        node.raw(),
-        relType.raw()
-      )
-      .findFirst().get()
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Optional<R> outOptionalE(N node, RT relType) {
-
-    return raw().outE(
-      node.raw(),
-      relType.raw()
-    )
-    .findFirst()
-    .map(
-      relType::edge
-    );
-  }
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Optional<T> outOptionalV(N node, RT relType) {
-
-    return raw().outV(
-      node.raw(),
-      relType.raw()
-    )
-    .findFirst()
-    .map(
-      relType.targetType()::vertex
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Stream<R> outManyE(N node, RT relType) {
-
-    return raw().outE(
-      node.raw(),
-      relType.raw()
-    ).map(
-      relType::edge
-    );
-  }
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Stream<T> outManyV(N node, RT relType) {
-
-    return raw().outV(
-      node.raw(),
-      relType.raw()
-    ).map(
-      relType.targetType()::vertex
-    );
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  /* #### in methods
-  */
+  /* #### Incoming edges */
   default <
     // src
     S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
@@ -389,6 +194,8 @@ interface TypedGraph <
       relType::edge
     );
   }
+
+  /* #### Incoming vertices */
   default <
     // src
     S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
@@ -412,150 +219,51 @@ interface TypedGraph <
     );
   }
 
+
+  /* #### Outgoing edges */
   default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // tgt
     N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
-  >
-  R inOneE(RT relType, N node) {
-
-    return relType.edge(
-      raw().inE(
-        node.raw(),
-        relType.raw()
-      )
-      .findFirst().get()
-    );
-  }
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromOne,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    //rel
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
+    // target node
+    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
+    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
   >
-  S inOneV(RT relType, N node) {
+  Stream<R> outE(N node, RT relType) {
 
-    return relType.sourceType().vertex(
-      raw().inV(
-        node.raw(),
-        relType.raw()
-      )
-      .findFirst().get()
-    );
-  }
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
-  >
-  Optional<R> inOptionalE(RT relType, N node) {
-
-    return raw().inE(
-      node.raw(),
-      relType.raw()
-    )
-    .findFirst()
-    .map(
-      relType::edge
-    );
-  }
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
-  >
-  Optional<S> inOptionalV(RT relType, N node) {
-
-    return raw().inV(
-      node.raw(),
-      relType.raw()
-    )
-    .findFirst()
-    .map(
-      relType.sourceType()::vertex
-    );
-  }
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
-  >
-  Stream<R> inManyE(RT relType, N node) {
-
-    return raw().inE(
+    return raw().outE(
       node.raw(),
       relType.raw()
     ).map(
       relType::edge
     );
   }
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>
-  >
-  Stream<S> inManyV(RT relType, N node) {
 
-    return raw().inV(
+  /* #### Outgoing vertices */
+  default <
+    N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,
+    NT extends TypedVertex.Type<N,NT,G,I,RV,RVT,RE,RET>,
+    //rel
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
+    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    // target node
+    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
+    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+  >
+  Stream<T> outV(N node, RT relType) {
+
+    return raw().outV (
       node.raw(),
       relType.raw()
     ).map(
-      relType.sourceType()::vertex
+      relType.targetType()::vertex
     );
   }
+
 }

--- a/src/main/java/com/bio4j/angulillos/TypedVertex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertex.java
@@ -70,11 +70,9 @@ interface TypedVertex <
     return self();
   }
 
-  /*
-    ### Getting incoming and outgoing relationships
+  /* ### Getting incoming and outgoing relationships */
 
-    For when you don't know anything about the arity, we have unbounded in/out methods which return `Stream`s
-  */
+  /* #### In-methods */
   default <
     // src
     S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
@@ -100,35 +98,6 @@ interface TypedVertex <
   >
   Stream<S> inV(RT relType) { return graph().inV( relType, self() ); }
 
-  /////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
-  >
-  R inOneE(RT relType) { return graph().inOneE( relType, self() ); }
-
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RVT,RE,RET>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RVT,RE,RET>,
-    SG extends TypedGraph<SG,I,RV,RVT,RE,RET>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
-  >
-  S inOneV(RT relType) { return graph().inOneV( relType, self() ); }
-
 
   default <
     // src
@@ -141,8 +110,7 @@ interface TypedVertex <
       TypedEdge.Type.FromAtMostOne,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
   >
-  Optional<R> inOptionalE(RT relType) { return graph().inOptionalE( relType, self() ); }
-
+  Optional<R> inOptionalE(RT relType) { return inE(relType).findFirst(); }
 
   default <
     // src
@@ -155,7 +123,7 @@ interface TypedVertex <
       TypedEdge.Type.FromAtMostOne,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
   >
-  Optional<S> inOptionalV(RT relType) { return graph().inOptionalV( relType, self() ); }
+  Optional<S> inOptionalV(RT relType) { return inV(relType).findFirst(); }
 
 
   default <
@@ -166,10 +134,10 @@ interface TypedVertex <
     // rel
     R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
     RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
+      TypedEdge.Type.FromOne,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
   >
-  Stream<R> inManyE(RT relType) { return graph().inManyE( relType, self() ); }
+  R inOneE(RT relType) { return inE(relType).findFirst().get(); }
 
 
   default <
@@ -180,18 +148,20 @@ interface TypedVertex <
     // rel
     R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G>,
     RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RVT,RE,RET, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
+      TypedEdge.Type.FromOne,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>
   >
-  Stream<S> inManyV(RT relType) { return graph().inManyV( relType, self() ); }
+  S inOneV(RT relType) { return inV(relType).findFirst().get(); }
 
+
+  /* #### Out-methods */
 
   default <
-    //rel
+    // rel
     R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
     RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
+    // tgt
     T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
     TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
     TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
@@ -200,11 +170,11 @@ interface TypedVertex <
 
 
   default <
-    //rel
+    // rel
     R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
     RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
+    // tgt
     T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
     TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
     TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
@@ -213,88 +183,61 @@ interface TypedVertex <
 
 
   default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Stream<R> outManyE(RT relType) { return graph().outManyE( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  Stream<T> outManyV(RT relType) { return graph().outManyV( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  T outOneV(RT relType) { return graph().outOneV( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
-    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
-  >
-  R outOneE(RT relType) { return graph().outOneE( self(), relType ); }
-
-
-  default <
-    //rel
+    // rel
     R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
     RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
       TypedEdge.Type.ToAtMostOne,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
+    // tgt
     T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
     TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
     TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
   >
-  Optional<R> outOptionalE(RT relType) { return graph().outOptionalE( self(), relType ); }
+  Optional<R> outOptionalE(RT relType) { return outE(relType).findFirst(); }
 
 
   default <
-    //rel
+    // rel
     R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
     RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
       TypedEdge.Type.ToAtMostOne,
     RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
-    // target node
+    // tgt
     T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
     TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
     TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
   >
-  Optional<T> outOptionalV(RT relType) { return graph().outOptionalV( self(), relType ); }
+  Optional<T> outOptionalV(RT relType) { return outV(relType).findFirst(); }
 
+
+  default <
+    // rel
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+      TypedEdge.Type.ToOne,
+    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    // tgt
+    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
+    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+  >
+  R outOneE(RT relType) { return outE(relType).findFirst().get(); }
+
+  default <
+    // rel
+    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG>,
+    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RVT,RE,RET, T,TT,TG> &
+      TypedEdge.Type.ToOne,
+    RG extends TypedGraph<RG,I,RV,RVT,RE,RET>,
+    // tgt
+    T extends TypedVertex<T,TT,TG,I,RV,RVT,RE,RET>,
+    TT extends TypedVertex.Type<T,TT,TG,I,RV,RVT,RE,RET>,
+    TG extends TypedGraph<TG,I,RV,RVT,RE,RET>
+  >
+  T outOneV(RT relType) { return outV(relType).findFirst().get(); }
+
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////////
 
   interface Type <
     N extends TypedVertex<N,NT,G,I,RV,RVT,RE,RET>,


### PR DESCRIPTION
All these in/out-One/Optional/Many-E/V methods in the `TypedGraph` have default implementations, based on the general in/out-E/V ones (by the way, `outManyE` is just _the same_ as `outE`).

I'm going to leave in the `TypedGraph` only in/out-E/V and move implementations of the rest of them to the `TypedVertex` (where they also have default implementations based on these graph ones). From the point of view of the API, you're going to use these things from a vertex, not the graph.