### PR TITLE
Experiment: reducing number of type parameters carried around

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,3 +6,8 @@ description  := "A Java API for typed property graphs with a lot of angulillos"
 
 bucketSuffix := "era7.com"
 javaVersion  := "1.8"
+
+excludeFilter in unmanagedSources :=
+  (excludeFilter in unmanagedSources).value ||
+  "*Index.java" ||
+  "*Query.java"

--- a/build.sbt
+++ b/build.sbt
@@ -10,4 +10,5 @@ javaVersion  := "1.8"
 excludeFilter in unmanagedSources :=
   (excludeFilter in unmanagedSources).value ||
   "*Index.java" ||
-  "*Query.java"
+  "*Query.java" ||
+  "*TwitterGraphTestSuite.java"

--- a/src/main/java/com/bio4j/angulillos/Property.java
+++ b/src/main/java/com/bio4j/angulillos/Property.java
@@ -7,11 +7,13 @@ package com.bio4j.angulillos;
 */
 interface Property <
   // the element type
-  N extends TypedElement<N,NT,G,I,RV,RE>, NT extends TypedElement.Type<N,NT,G,I,RV,RE>,
+  N extends TypedElement<N,NT,RV,RE>,
+  NT extends TypedElement.Type<N,NT,RV,RE>,
   // the property type and its value type
-  P extends Property<N,NT,P,V,G,I,RV,RE>, V,
+  P extends Property<N,NT,P,V,RV,RE>,
+  V,
   // graph
-  G extends TypedGraph<G,I,RV,RE>, I extends UntypedGraph<RV,RE>, RV,RE
+  RV,RE
 >
 {
 

--- a/src/main/java/com/bio4j/angulillos/TypedEdge.java
+++ b/src/main/java/com/bio4j/angulillos/TypedEdge.java
@@ -11,20 +11,18 @@ package com.bio4j.angulillos;
 */
 interface TypedEdge <
   // src
-  S extends TypedVertex<S,ST,SG,I,RV,RE>,
-  ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-  SG extends TypedGraph<SG,I,RV,RE>,
+  S  extends      TypedVertex<S,ST, RV,RE>,
+  ST extends TypedVertex.Type<S,ST, RV,RE>,
   // rel
-  R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
-  RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
-  RG extends TypedGraph<RG,I,RV,RE>,
-  I extends UntypedGraph<RV,RE>, RV,RE,
+  R  extends      TypedEdge<S,ST, R,RT, T,TT, RV,RE>,
+  RT extends TypedEdge.Type<S,ST, R,RT, T,TT, RV,RE>,
   // tgt
-  T extends TypedVertex<T,TT,TG,I,RV,RE>,
-  TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-  TG extends TypedGraph<TG,I,RV,RE>
+  T  extends      TypedVertex<T,TT, RV,RE>,
+  TT extends TypedVertex.Type<T,TT, RV,RE>,
+  // raws
+  RV,RE
 >
-  extends TypedElement<R,RT,RG,I,RV,RE>
+  extends TypedElement<R,RT,RV,RE>
 {
 
   /* `raw` gives you the raw edge underlying this instance; see [untyped graph](UntypedGraph.java.md) */
@@ -39,14 +37,14 @@ interface TypedEdge <
 
   @Override
   default <
-    P extends Property<R,RT,P,V,RG,I,RV,RE>,
+    P extends Property<R,RT,P,V,RV,RE>,
     V
   >
   V get(P property) { return graph().getProperty(self(), property); }
 
   @Override
   default <
-    P extends Property<R,RT,P,V,RG,I,RV,RE>,
+    P extends Property<R,RT,P,V,RV,RE>,
     V
   >
   R set(P property, V value) {
@@ -64,20 +62,17 @@ interface TypedEdge <
 
   interface Type <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
+    S  extends TypedVertex<S,ST, RV,RE>,
+    ST extends TypedVertex.Type<S,ST, RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    I extends UntypedGraph<RV,RE>, RV,RE,
+    R  extends TypedEdge<S,ST, R,RT, T,TT, RV,RE>,
+    RT extends TypedEdge.Type<S,ST, R,RT, T,TT, RV,RE>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
+    T  extends TypedVertex<T,TT, RV,RE>,
+    TT extends TypedVertex.Type<T,TT, RV,RE>,
+    RV,RE
   > extends
-    TypedElement.Type<R,RT,RG,I,RV,RE>,
+    TypedElement.Type<R,RT, RV,RE>,
     HasArity
   {
 

--- a/src/main/java/com/bio4j/angulillos/TypedElement.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElement.java
@@ -14,10 +14,10 @@ package com.bio4j.angulillos;
   `E` refers to the element itself, and `ET` its type. You cannot define one without defining the other.
 */
 interface TypedElement <
-  E extends TypedElement<E,ET,G,I,RV,RE>,
-  ET extends TypedElement.Type<E,ET,G,I,RV,RE>,
-  G extends TypedGraph<G,I,RV,RE>,
-  I extends UntypedGraph<RV,RE>, RV,RE
+  E  extends      TypedElement<E,ET, RV,RE>,
+  ET extends TypedElement.Type<E,ET, RV,RE>,
+  // raws
+  RV,RE
 >
 {
 
@@ -31,18 +31,21 @@ interface TypedElement <
   Object raw();
 
   /* The graph in which this element lives. */
+  <
+    G extends TypedGraph<G,RV,RE>
+  >
   G graph();
 
   /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
   <
-    P extends Property<E,ET,P,V,G,I,RV,RE>,
+    P extends Property<E,ET,P,V,RV,RE>,
     V
   >
   V get(P property);
 
   /* `set` sets the value of a `property` for this element. Again, you can only set properties that this element has, using values of the corresponding property value type. */
   <
-    P extends Property<E,ET,P,V,G,I,RV,RE>,
+    P extends Property<E,ET,P,V,RV,RE>,
     V
   >
   E set(P property, V value);
@@ -53,13 +56,12 @@ interface TypedElement <
     Element types are also used as factories for constructing instances of the corresponding elements.
   */
   interface Type <
-    E extends TypedElement<E,ET,G,I,RV,RE>,
-    ET extends TypedElement.Type<E,ET,G,I,RV,RE>,
-    G extends TypedGraph<G,I,RV,RE>,
-    I extends UntypedGraph<RV,RE>, RV,RE
+    E extends TypedElement<E,ET,RV,RE>,
+    ET extends TypedElement.Type<E,ET,RV,RE>,
+    RV,RE
   > {
     default String name() { return getClass().getCanonicalName(); }
 
-    G graph();
+    // G graph();
   }
 }

--- a/src/main/java/com/bio4j/angulillos/TypedElement.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElement.java
@@ -31,10 +31,7 @@ interface TypedElement <
   Object raw();
 
   /* The graph in which this element lives. */
-  <
-    G extends TypedGraph<G,RV,RE>
-  >
-  G graph();
+  TypedGraph<RV,RE> graph();
 
   /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
   <

--- a/src/main/java/com/bio4j/angulillos/TypedElement.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElement.java
@@ -31,10 +31,7 @@ interface TypedElement <
   Object raw();
 
   /* The graph in which this element lives. */
-  <
-    G extends TypedGraph<G,RV,RE>
-  >
-  G graph();
+  TypedGraph<G,RV,RE> graph();
 
   /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
   <

--- a/src/main/java/com/bio4j/angulillos/TypedElement.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElement.java
@@ -31,7 +31,10 @@ interface TypedElement <
   Object raw();
 
   /* The graph in which this element lives. */
-  TypedGraph<G,RV,RE> graph();
+  <
+    G extends TypedGraph<G,RV,RE>
+  >
+  G graph();
 
   /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
   <

--- a/src/main/java/com/bio4j/angulillos/TypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/TypedGraph.java
@@ -12,45 +12,45 @@ import java.util.Optional;
   A `TypedGraph` is, unsurprisingly, the typed version of [UntypedGraph](UntypedGraph.java.md).
 */
 interface TypedGraph <
-  G extends TypedGraph<G,I,RV,RE>,
-  I extends UntypedGraph<RV,RE>, RV,RE
+  G extends TypedGraph<G,RV,RE>,
+  RV,RE
 >
 {
 
-  I raw();
+  UntypedGraph<RV,RE> raw();
 
-  default <
-    V extends TypedVertex<V,VT,G,I,RV,RE>,
-    VT extends TypedVertex.Type<V,VT,G,I,RV,RE>
-  >
-  V addVertex(VT vertexType) {
-
-    return vertexType.vertex(
-      raw().addVertex( vertexType.name() )
-    );
-  }
-
-  /* adds an edge; note that this method does not set any properties. As it needs to be called by vertices in possibly different graphs, all the graph bounds are free with respect to G. */
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  R addEdge(S from, RT relType, T to) {
-
-    return relType.edge(
-      raw().addEdge( from.raw(), relType.name(), to.raw() )
-    );
-  }
+  // default <
+  //   V extends TypedVertex<V,VT,RV,RE>,
+  //   VT extends TypedVertex.Type<V,VT,RV,RE>
+  // >
+  // V addVertex(VT vertexType) {
+  //
+  //   return vertexType.vertex(
+  //     raw().addVertex( vertexType.name() )
+  //   );
+  // }
+  //
+  // /* adds an edge; note that this method does not set any properties. As it needs to be called by vertices in possibly different graphs, all the graph bounds are free with respect to G. */
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+  //   RT extends TypedEdge.Type<S,ST,SG,R,RT,RG,I,RV,RE,T,TT,TG>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // R addEdge(S from, RT relType, T to) {
+  //
+  //   return relType.edge(
+  //     raw().addEdge( from.raw(), relType.name(), to.raw() )
+  //   );
+  // }
 
   /*
     ### properties
@@ -58,9 +58,9 @@ interface TypedGraph <
     These methods are used for setting and getting properties on vertices and edges.
   */
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    P extends Property<N,NT,P,V,G,I,RV,RE>,
+    N  extends TypedVertex<N,NT,RV,RE>,
+    NT extends TypedVertex.Type<N,NT,RV,RE>,
+    P  extends Property<N,NT,P,V,RV,RE>,
     V
   >
   V getProperty(N node, P property) {
@@ -71,17 +71,16 @@ interface TypedGraph <
   /* Get the value of a property from an edge of G. */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
+    S extends TypedVertex<S,ST, RV,RE>,
+    ST extends TypedVertex.Type<S,ST, RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    R extends TypedEdge<S,ST, R,RT, T,TT, RV,RE>,
+    RT extends TypedEdge.Type<S,ST, R,RT, T,TT, RV,RE>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>,
-    P extends Property<R,RT,P,V,G,I,RV,RE>,
+    T extends TypedVertex<T,TT, RV,RE>,
+    TT extends TypedVertex.Type<T,TT, RV,RE>,
+    // prop
+    P extends Property<R,RT, P,V, RV,RE>,
     V
   >
   V getProperty(R edge, P property) {
@@ -91,9 +90,9 @@ interface TypedGraph <
 
   /* Sets the value of a property for a vertex of G. */
   default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    P extends Property<N,NT,P,V,G,I,RV,RE>,
+    N extends TypedVertex<N,NT, RV,RE>,
+    NT extends TypedVertex.Type<N,NT, RV,RE>,
+    P extends Property<N,NT, P,V, RV,RE>,
     V
   >
   G setProperty(N node, P property, V value) {
@@ -105,17 +104,16 @@ interface TypedGraph <
   /* Sets the value of a property for an edge of G. */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
+    S extends TypedVertex<S,ST, RV,RE>,
+    ST extends TypedVertex.Type<S,ST, RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    R extends TypedEdge<S,ST, R,RT, T,TT, RV,RE>,
+    RT extends TypedEdge.Type<S,ST, R,RT, T,TT, RV,RE>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>,
-    P extends Property<R,RT,P,V,G,I,RV,RE>,
+    T extends TypedVertex<T,TT, RV,RE>,
+    TT extends TypedVertex.Type<T,TT, RV,RE>,
+    // prop
+    P extends Property<R,RT, P,V, RV,RE>,
     V
   >
   G setProperty(R edge, P property, V value) {
@@ -131,16 +129,14 @@ interface TypedGraph <
   */
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
+    S  extends      TypedVertex<S,ST, RV,RE>,
+    ST extends TypedVertex.Type<S,ST, RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    R  extends      TypedEdge<S,ST, R,RT, T,TT, RV,RE>,
+    RT extends TypedEdge.Type<S,ST, R,RT, T,TT, RV,RE>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
+    T  extends      TypedVertex<T,TT, RV,RE>,
+    TT extends TypedVertex.Type<T,TT, RV,RE>
   >
   S source(R edge) {
 
@@ -151,16 +147,14 @@ interface TypedGraph <
 
   default <
     // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
+    S  extends      TypedVertex<S,ST, RV,RE>,
+    ST extends TypedVertex.Type<S,ST, RV,RE>,
     // rel
-    R extends TypedEdge<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
-    RT extends TypedEdge.Type<S,ST,SG,R,RT,G,I,RV,RE,T,TT,TG>,
+    R  extends      TypedEdge<S,ST, R,RT, T,TT, RV,RE>,
+    RT extends TypedEdge.Type<S,ST, R,RT, T,TT, RV,RE>,
     // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
+    T  extends      TypedVertex<T,TT, RV,RE>,
+    TT extends TypedVertex.Type<T,TT, RV,RE>
   >
   T target(R edge) {
 
@@ -170,392 +164,392 @@ interface TypedGraph <
   }
 
 
-  /* ### Incident edges from vertices */
-
-  /*
-    #### out methods
-
-    gets the out edges of a vertex N of G.
-  */
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<R> outE(N node, RT relType) {
-
-    return raw().outE(
-      node.raw(),
-      relType.name()
-    ).map(
-      relType::edge
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<T> outV(N node, RT relType) {
-
-    return raw().outV (
-      node.raw(),
-      relType.name()
-    ).map(
-      relType.targetType()::vertex
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  R outOneE(N node, RT relType) {
-
-    // we know it has one!
-    return relType.edge(
-      raw().outE(
-        node.raw(),
-        relType.name()
-      )
-      .findFirst().get()
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  T outOneV(N node, RT relType) {
-
-    return relType.targetType().vertex(
-      raw().outV(
-        node.raw(),
-        relType.name()
-      )
-      .findFirst().get()
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Optional<R> outOptionalE(N node, RT relType) {
-
-    return raw().outE(
-      node.raw(),
-      relType.name()
-    )
-    .findFirst()
-    .map(
-      relType::edge
-    );
-  }
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Optional<T> outOptionalV(N node, RT relType) {
-
-    return raw().outV(
-      node.raw(),
-      relType.name()
-    )
-    .findFirst()
-    .map(
-      relType.targetType()::vertex
-    );
-  }
-
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<R> outManyE(N node, RT relType) {
-
-    return raw().outE(
-      node.raw(),
-      relType.name()
-    ).map(
-      relType::edge
-    );
-  }
-  default <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<T> outManyV(N node, RT relType) {
-
-    return raw().outV(
-      node.raw(),
-      relType.name()
-    ).map(
-      relType.targetType()::vertex
-    );
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  /* #### in methods
-  */
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  Stream<R> inE(RT relType, N node) {
-
-    return raw().inE(
-      node.raw(),
-      relType.name()
-    ).map(
-      relType::edge
-    );
-  }
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  Stream<S> inV(RT relType, N node) {
-
-    return raw().inV(
-      node.raw(),
-      relType.name()
-    ).map(
-      relType.sourceType()::vertex
-    );
-  }
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  R inOneE(RT relType, N node) {
-
-    return relType.edge(
-      raw().inE(
-        node.raw(),
-        relType.name()
-      )
-      .findFirst().get()
-    );
-  }
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  S inOneV(RT relType, N node) {
-
-    return relType.sourceType().vertex(
-      raw().inV(
-        node.raw(),
-        relType.name()
-      )
-      .findFirst().get()
-    );
-  }
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  Optional<R> inOptionalE(RT relType, N node) {
-
-    return raw().inE(
-      node.raw(),
-      relType.name()
-    )
-    .findFirst()
-    .map(
-      relType::edge
-    );
-  }
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  Optional<S> inOptionalV(RT relType, N node) {
-
-    return raw().inV(
-      node.raw(),
-      relType.name()
-    )
-    .findFirst()
-    .map(
-      relType.sourceType()::vertex
-    );
-  }
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  Stream<R> inManyE(RT relType, N node) {
-
-    return raw().inE(
-      node.raw(),
-      relType.name()
-    ).map(
-      relType::edge
-    );
-  }
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
-  >
-  Stream<S> inManyV(RT relType, N node) {
-
-    return raw().inV(
-      node.raw(),
-      relType.name()
-    ).map(
-      relType.sourceType()::vertex
-    );
-  }
+  // /* ### Incident edges from vertices */
+  //
+  // /*
+  //   #### out methods
+  //
+  //   gets the out edges of a vertex N of G.
+  // */
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<R> outE(N node, RT relType) {
+  //
+  //   return raw().outE(
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType::edge
+  //   );
+  // }
+  //
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<T> outV(N node, RT relType) {
+  //
+  //   return raw().outV (
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType.targetType()::vertex
+  //   );
+  // }
+  //
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // R outOneE(N node, RT relType) {
+  //
+  //   // we know it has one!
+  //   return relType.edge(
+  //     raw().outE(
+  //       node.raw(),
+  //       relType.name()
+  //     )
+  //     .findFirst().get()
+  //   );
+  // }
+  //
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // T outOneV(N node, RT relType) {
+  //
+  //   return relType.targetType().vertex(
+  //     raw().outV(
+  //       node.raw(),
+  //       relType.name()
+  //     )
+  //     .findFirst().get()
+  //   );
+  // }
+  //
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Optional<R> outOptionalE(N node, RT relType) {
+  //
+  //   return raw().outE(
+  //     node.raw(),
+  //     relType.name()
+  //   )
+  //   .findFirst()
+  //   .map(
+  //     relType::edge
+  //   );
+  // }
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Optional<T> outOptionalV(N node, RT relType) {
+  //
+  //   return raw().outV(
+  //     node.raw(),
+  //     relType.name()
+  //   )
+  //   .findFirst()
+  //   .map(
+  //     relType.targetType()::vertex
+  //   );
+  // }
+  //
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<R> outManyE(N node, RT relType) {
+  //
+  //   return raw().outE(
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType::edge
+  //   );
+  // }
+  // default <
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<T> outManyV(N node, RT relType) {
+  //
+  //   return raw().outV(
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType.targetType()::vertex
+  //   );
+  // }
+  //
+  // ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // /* #### in methods
+  // */
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // Stream<R> inE(RT relType, N node) {
+  //
+  //   return raw().inE(
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType::edge
+  //   );
+  // }
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // Stream<S> inV(RT relType, N node) {
+  //
+  //   return raw().inV(
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType.sourceType()::vertex
+  //   );
+  // }
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // R inOneE(RT relType, N node) {
+  //
+  //   return relType.edge(
+  //     raw().inE(
+  //       node.raw(),
+  //       relType.name()
+  //     )
+  //     .findFirst().get()
+  //   );
+  // }
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // S inOneV(RT relType, N node) {
+  //
+  //   return relType.sourceType().vertex(
+  //     raw().inV(
+  //       node.raw(),
+  //       relType.name()
+  //     )
+  //     .findFirst().get()
+  //   );
+  // }
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // Optional<R> inOptionalE(RT relType, N node) {
+  //
+  //   return raw().inE(
+  //     node.raw(),
+  //     relType.name()
+  //   )
+  //   .findFirst()
+  //   .map(
+  //     relType::edge
+  //   );
+  // }
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // Optional<S> inOptionalV(RT relType, N node) {
+  //
+  //   return raw().inV(
+  //     node.raw(),
+  //     relType.name()
+  //   )
+  //   .findFirst()
+  //   .map(
+  //     relType.sourceType()::vertex
+  //   );
+  // }
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // Stream<R> inManyE(RT relType, N node) {
+  //
+  //   return raw().inE(
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType::edge
+  //   );
+  // }
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   N extends TypedVertex<N,NT,G,I,RV,RE>,
+  //   NT extends TypedVertex.Type<N,NT,G,I,RV,RE>
+  // >
+  // Stream<S> inManyV(RT relType, N node) {
+  //
+  //   return raw().inV(
+  //     node.raw(),
+  //     relType.name()
+  //   ).map(
+  //     relType.sourceType()::vertex
+  //   );
+  // }
 }

--- a/src/main/java/com/bio4j/angulillos/TypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/TypedGraph.java
@@ -11,10 +11,7 @@ import java.util.Optional;
 
   A `TypedGraph` is, unsurprisingly, the typed version of [UntypedGraph](UntypedGraph.java.md).
 */
-interface TypedGraph <
-  G extends TypedGraph<G,RV,RE>,
-  RV,RE
->
+interface TypedGraph <RV,RE>
 {
 
   UntypedGraph<RV,RE> raw();
@@ -95,7 +92,7 @@ interface TypedGraph <
     P extends Property<N,NT, P,V, RV,RE>,
     V
   >
-  G setProperty(N node, P property, V value) {
+  TypedGraph<RV,RE> setProperty(N node, P property, V value) {
 
     raw().setPropertyV(node.raw(), property.name(), value);
     return node.graph();
@@ -116,7 +113,7 @@ interface TypedGraph <
     P extends Property<R,RT, P,V, RV,RE>,
     V
   >
-  G setProperty(R edge, P property, V value) {
+  TypedGraph<RV,RE> setProperty(R edge, P property, V value) {
 
     raw().setPropertyE(edge.raw(), property.name(), value);
     return edge.graph();

--- a/src/main/java/com/bio4j/angulillos/TypedVertex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertex.java
@@ -10,50 +10,64 @@ import java.util.stream.Stream;
   A typed vertex. A vertex and its type need to be defined at the same time. The vertex keeps a reference of its type, while the type works as a factory for creating vertices with that type.
 */
 interface TypedVertex <
-  N extends TypedVertex<N,NT,G,I,RV,RE>,
-  NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-  G extends TypedGraph<G,I,RV,RE>,
-  I extends UntypedGraph<RV,RE>, RV,RE
->
-  extends TypedElement<N,NT,G,I,RV,RE>
+  N  extends      TypedVertex<N,NT,RV,RE>,
+  NT extends TypedVertex.Type<N,NT,RV,RE>,
+  // raws
+  RV,RE
+> extends
+  TypedElement<N,NT,RV,RE>
 {
+
+  interface Type <
+    N  extends      TypedVertex<N,NT, RV,RE>,
+    NT extends TypedVertex.Type<N,NT, RV,RE>,
+    // raws
+    RV,RE
+  > extends
+    TypedElement.Type<N,NT,RV,RE>
+  {
+
+    /* Constructs a value of the typed vertex of this type */
+    N vertex(RV rawVertex);
+  }
+
 
   @Override
   RV raw();
 
-  /*
-    ### Create relationships in/out of this node
-
-    There are two methods for creating new relationships, into and out of this node respectively. Their implementation delegates to the graph methods.
-  */
-  default <
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  R addInEdge(S from, RT relType) { return graph().addEdge( from, relType, self() ); }
-
-
-  default <
-    // rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // tgt
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  R addOutEdge(RT relType, T to) { return graph().addEdge( self(), relType, to ); }
+  // /*
+  //   ### Create relationships in/out of this node
+  //
+  //   There are two methods for creating new relationships, into and out of this node respectively. Their implementation delegates to the graph methods.
+  // */
+  // default <
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // R addInEdge(S from, RT relType) { return graph().addEdge( from, relType, self() ); }
+  //
+  //
+  // default <
+  //   // rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // tgt
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // R addOutEdge(RT relType, T to) { return graph().addEdge( self(), relType, to ); }
 
 
   /* ### Properties */
   @Override
   default <
-    P extends Property<N,NT,P,V,G,I,RV,RE>,
+    P extends Property<N,NT,P,V,RV,RE>,
     V
   >
   V get(P property) { return graph().getProperty(self(), property); }
@@ -61,7 +75,7 @@ interface TypedVertex <
 
   @Override
   default <
-    P extends Property<N,NT,P,V,G,I,RV,RE>,
+    P extends Property<N,NT,P,V,RV,RE>,
     V
   >
   N set(P property, V value) {
@@ -70,242 +84,230 @@ interface TypedVertex <
     return self();
   }
 
-  /*
-    ### Getting incoming and outgoing relationships
-
-    For when you don't know anything about the arity, we have unbounded in/out methods which return `Stream`s
-  */
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  Stream<R> inE(RT relType) { return graph().inE( relType, self() ); }
-
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  Stream<S> inV(RT relType) { return graph().inV( relType, self() ); }
+  // /*
+  //   ### Getting incoming and outgoing relationships
+  //
+  //   For when you don't know anything about the arity, we have unbounded in/out methods which return `Stream`s
+  // */
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // Stream<R> inE(RT relType) { return graph().inE( relType, self() ); }
+  //
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // Stream<S> inV(RT relType) { return graph().inV( relType, self() ); }
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // R inOneE(RT relType) { return graph().inOneE( relType, self() ); }
+  //
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // S inOneV(RT relType) { return graph().inOneV( relType, self() ); }
+  //
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // Optional<R> inOptionalE(RT relType) { return graph().inOptionalE( relType, self() ); }
+  //
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // Optional<S> inOptionalV(RT relType) { return graph().inOptionalV( relType, self() ); }
+  //
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // Stream<R> inManyE(RT relType) { return graph().inManyE( relType, self() ); }
+  //
+  //
+  // default <
+  //   // src
+  //   S extends TypedVertex<S,ST,SG,I,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
+  //   SG extends TypedGraph<SG,I,RV,RE>,
+  //   // rel
+  //   R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
+  //   RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
+  //     TypedEdge.Type.FromAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>
+  // >
+  // Stream<S> inManyV(RT relType) { return graph().inManyV( relType, self() ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<R> outE(RT relType) { return graph().outE( self(), relType ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<T> outV(RT relType) { return graph().outV( self(), relType ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<R> outManyE(RT relType) { return graph().outManyE( self(), relType ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtLeastOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Stream<T> outManyV(RT relType) { return graph().outManyV( self(), relType ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // T outOneV(RT relType) { return graph().outOneV( self(), relType ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // R outOneE(RT relType) { return graph().outOneE( self(), relType ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Optional<R> outOptionalE(RT relType) { return graph().outOptionalE( self(), relType ); }
+  //
+  //
+  // default <
+  //   //rel
+  //   R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
+  //   RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
+  //     TypedEdge.Type.ToAtMostOne,
+  //   RG extends TypedGraph<RG,I,RV,RE>,
+  //   // target node
+  //   T extends TypedVertex<T,TT,TG,I,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
+  //   TG extends TypedGraph<TG,I,RV,RE>
+  // >
+  // Optional<T> outOptionalV(RT relType) { return graph().outOptionalV( self(), relType ); }
+  //
 
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  R inOneE(RT relType) { return graph().inOneE( relType, self() ); }
-
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromOne,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  S inOneV(RT relType) { return graph().inOneV( relType, self() ); }
-
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  Optional<R> inOptionalE(RT relType) { return graph().inOptionalE( relType, self() ); }
-
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  Optional<S> inOptionalV(RT relType) { return graph().inOptionalV( relType, self() ); }
-
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  Stream<R> inManyE(RT relType) { return graph().inManyE( relType, self() ); }
-
-
-  default <
-    // src
-    S extends TypedVertex<S,ST,SG,I,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,SG,I,RV,RE>,
-    SG extends TypedGraph<SG,I,RV,RE>,
-    // rel
-    R extends TypedEdge<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G>,
-    RT extends TypedEdge.Type<S,ST,SG, R,RT,RG,I,RV,RE, N,NT,G> &
-      TypedEdge.Type.FromAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>
-  >
-  Stream<S> inManyV(RT relType) { return graph().inManyV( relType, self() ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<R> outE(RT relType) { return graph().outE( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<T> outV(RT relType) { return graph().outV( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<R> outManyE(RT relType) { return graph().outManyE( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtLeastOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Stream<T> outManyV(RT relType) { return graph().outManyV( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  T outOneV(RT relType) { return graph().outOneV( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  R outOneE(RT relType) { return graph().outOneE( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Optional<R> outOptionalE(RT relType) { return graph().outOptionalE( self(), relType ); }
-
-
-  default <
-    //rel
-    R extends TypedEdge<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG>,
-    RT extends TypedEdge.Type<N,NT,G, R,RT,RG,I,RV,RE, T,TT,TG> &
-      TypedEdge.Type.ToAtMostOne,
-    RG extends TypedGraph<RG,I,RV,RE>,
-    // target node
-    T extends TypedVertex<T,TT,TG,I,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,TG,I,RV,RE>,
-    TG extends TypedGraph<TG,I,RV,RE>
-  >
-  Optional<T> outOptionalV(RT relType) { return graph().outOptionalV( self(), relType ); }
-
-
-  interface Type <
-    N extends TypedVertex<N,NT,G,I,RV,RE>,
-    NT extends TypedVertex.Type<N,NT,G,I,RV,RE>,
-    G extends TypedGraph<G,I,RV,RE>,
-    I extends UntypedGraph<RV,RE>, RV,RE
-  > extends
-    TypedElement.Type<N,NT,G,I,RV,RE>
-  {
-
-    /* Constructs a value of the typed vertex of this type */
-    N vertex(RV rawVertex);
-  }
 }

--- a/src/test/java/com/bio4j/angulillos/TwitterGraph.java
+++ b/src/test/java/com/bio4j/angulillos/TwitterGraph.java
@@ -7,28 +7,26 @@ public abstract class TwitterGraph <
   RV,RE
 >
 implements
-  TypedGraph<
-    TwitterGraph<I,RV,RE>,
-    I, RV,RE
-  >
+  TypedGraph<RV,RE>
 {
 
   protected I rawGraph = null;
   public TwitterGraph(I graph) { rawGraph = graph; }
-  @Override public I raw() { return rawGraph; }
+  @Override
+  public I raw() { return rawGraph; }
 
   // vertices
-  public abstract TwitterGraph<I,RV,RE>.UserType        User();
-  public abstract TwitterGraph<I,RV,RE>.TweetType       Tweet();
+  public abstract TwitterGraph<I,RV,RE>.UserType  User();
+  public abstract TwitterGraph<I,RV,RE>.TweetType Tweet();
   // edges
-  public abstract TwitterGraph<I,RV,RE>.PostedType      Posted();
-  public abstract TwitterGraph<I,RV,RE>.RepliesToType   RepliesTo();
-  public abstract TwitterGraph<I,RV,RE>.FollowsType     Follows();
+  public abstract TwitterGraph<I,RV,RE>.PostedType    Posted();
+  public abstract TwitterGraph<I,RV,RE>.RepliesToType RepliesTo();
+  public abstract TwitterGraph<I,RV,RE>.FollowsType   Follows();
 
-  /* ### Vertices and their types
-  */
-  /* #### User
-  */
+  /* ### Vertices and their types */
+
+  /* #### User */
+
   public final class UserType
   extends
     VertexType<
@@ -36,12 +34,9 @@ implements
       TwitterGraph<I,RV,RE>.UserType
     >
   {
-    public UserType(RVT raw) { super(raw); }
+    @Override public final User vertex(RV vertex) { return new User(vertex); }
 
-    @Override public final User vertex(RV vertex) { return new User(vertex, this); }
-
-    /* ##### User properties
-    */
+    /* ##### User properties */
     public final name name = new name();
     public final class name extends Property<User,UserType,name,String> {
       public name() { super(UserType.this); }
@@ -61,7 +56,7 @@ implements
       TwitterGraph<I,RV,RE>.UserType
     >
   {
-    public User(RV vertex, UserType type) { super(vertex, type); }
+    public User(RV vertex) { super(vertex, new UserType()); }
     @Override public final User self() { return this; }
   }
 
@@ -74,9 +69,7 @@ implements
       TwitterGraph<I,RV,RE>.TweetType
     >
   {
-    public TweetType(RVT raw) { super(raw); }
-
-    @Override public final Tweet vertex(RV vertex) { return new Tweet(vertex, this); }
+    @Override public final Tweet vertex(RV vertex) { return new Tweet(vertex); }
 
     /* ##### Tweet properties
     */
@@ -99,7 +92,7 @@ implements
       TwitterGraph<I,RV,RE>.TweetType
     >
   {
-    public Tweet(RV vertex, TweetType type) { super(vertex, type); }
+    public Tweet(RV vertex) { super(vertex, new TweetType()); }
     @Override public final Tweet self() { return this; }
   }
 
@@ -119,10 +112,11 @@ implements
     // t.inV(posted) = one
     OneToAny
   {
-    public PostedType(RET edgeType) { super(TwitterGraph.this.User(), edgeType, TwitterGraph.this.Tweet()); }
+    public PostedType() { super(TwitterGraph.this.User(), TwitterGraph.this.Tweet()); }
 
-    @Override public final Posted edge(RE edge) { return new Posted(edge, this); }
+    @Override public final Posted edge(RE edge) { return new Posted(edge); }
   }
+
   public final class Posted
   extends
     Edge<
@@ -131,7 +125,7 @@ implements
       TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType
     >
   {
-    public Posted(RE edge, PostedType type) { super(edge, type); }
+    public Posted(RE edge) { super(edge, new PostedType()); }
     @Override public final Posted self() { return this; }
   }
 
@@ -145,9 +139,9 @@ implements
   implements
     AnyToAny
   {
-    public FollowsType(RET edgeType) { super(TwitterGraph.this.User(), edgeType, TwitterGraph.this.User()); }
+    public FollowsType() { super(TwitterGraph.this.User(), TwitterGraph.this.User()); }
 
-    @Override public final Follows edge(RE edge) { return new Follows(edge, this); }
+    @Override public final Follows edge(RE edge) { return new Follows(edge); }
   }
   public final class Follows
   extends
@@ -157,7 +151,7 @@ implements
       TwitterGraph<I,RV,RE>.User,TwitterGraph<I,RV,RE>.UserType
     >
   {
-    public Follows(RE edge, FollowsType type) { super(edge, type); }
+    public Follows(RE edge) { super(edge, new FollowsType()); }
     @Override public final Follows self() { return this; }
   }
 
@@ -172,10 +166,11 @@ implements
     // a tweet can be a reply to at most one tweet
     AnyToAtMostOne
   {
-    public RepliesToType(RET edgeType) { super(TwitterGraph.this.Tweet(), edgeType, TwitterGraph.this.Tweet()); }
+    public RepliesToType() { super(TwitterGraph.this.Tweet(), TwitterGraph.this.Tweet()); }
 
-    @Override public final RepliesTo edge(RE edge) { return new RepliesTo(edge, this); }
+    @Override public final RepliesTo edge(RE edge) { return new RepliesTo(edge); }
   }
+
   public final class RepliesTo
   extends
     Edge<
@@ -184,7 +179,7 @@ implements
       TwitterGraph<I,RV,RE>.Tweet,TwitterGraph<I,RV,RE>.TweetType
     >
   {
-    public RepliesTo(RE edge, RepliesToType type) { super(edge, type); }
+    public RepliesTo(RE edge) { super(edge, new RepliesToType()); }
     @Override public final RepliesTo self() { return this; }
   }
 
@@ -210,21 +205,19 @@ implements
   */
 
   public abstract class ElementType<
-    E extends TwitterGraph<I, RV,RE>.Element<E, ET>,
+    E  extends TwitterGraph<I, RV,RE>.Element<E, ET>,
     ET extends TwitterGraph<I, RV,RE>.ElementType<E, ET>
   >
   implements
-    TypedElement.Type<E,ET,TwitterGraph<I,RV,RE>, I, RV,RE>
-  {
-    @Override public final TwitterGraph<I,RV,RE> graph() { return TwitterGraph.this; }
-  }
+    TypedElement.Type<E,ET, RV,RE>
+  {}
 
   public abstract class Element<
     E extends TwitterGraph<I, RV,RE>.Element<E,ET>,
     ET extends TwitterGraph<I, RV,RE>.ElementType<E,ET>
   >
   implements
-    TypedElement<E,ET,TwitterGraph<I, RV,RE>, I, RV,RE>
+    TypedElement<E,ET, RV,RE>
   {
     @Override public final TwitterGraph<I, RV,RE> graph() { return TwitterGraph.this; }
   }
@@ -236,12 +229,8 @@ implements
   extends
     TwitterGraph<I,RV,RE>.ElementType<V,VT>
   implements
-    com.bio4j.angulillos.TypedVertex.Type<V,VT,TwitterGraph<I, RV,RE>, I,RV,RE>
-  {
-    private final RVT raw;
-    protected VertexType(RVT type) { this.raw = type; }
-    @Override public final RVT raw() { return this.raw; }
-  }
+    com.bio4j.angulillos.TypedVertex.Type<V,VT, RV,RE>
+  {}
 
   public abstract class Vertex<
     V extends TwitterGraph<I, RV,RE>.Vertex<V,VT>,
@@ -250,7 +239,7 @@ implements
   extends
     TwitterGraph<I,RV,RE>.Element<V,VT>
   implements
-    com.bio4j.angulillos.TypedVertex<V,VT,TwitterGraph<I, RV,RE>, I,RV,RE>
+    com.bio4j.angulillos.TypedVertex<V,VT, RV,RE>
   {
     private final RV raw;
     private final VT type;
@@ -263,50 +252,50 @@ implements
   }
 
   public abstract class EdgeType<
-    S extends TwitterGraph<I, RV,RE>.Vertex<S,ST>,
+    S  extends TwitterGraph<I, RV,RE>.Vertex<S,ST>,
     ST extends TwitterGraph<I, RV,RE>.VertexType<S,ST>,
-    E extends TwitterGraph<I, RV,RE>.Edge<S,ST,E,ET,T,TT>,
-    ET extends TwitterGraph<I, RV,RE>.EdgeType<S,ST,E,ET,T,TT>,
-    T extends TwitterGraph<I, RV,RE>.Vertex<T,TT>,
+    E  extends TwitterGraph<I, RV,RE>.Edge<S,ST, E,ET, T,TT>,
+    ET extends TwitterGraph<I, RV,RE>.EdgeType<S,ST, E,ET, T,TT>,
+    T  extends TwitterGraph<I, RV,RE>.Vertex<T,TT>,
     TT extends TwitterGraph<I, RV,RE>.VertexType<T,TT>
   >
   extends
     TwitterGraph<I,RV,RE>.ElementType<E,ET>
   implements
     com.bio4j.angulillos.TypedEdge.Type<
-      S, ST, TwitterGraph<I, RV,RE>,
-      E, ET, TwitterGraph<I, RV,RE>, I, RV,RE,
-      T, TT, TwitterGraph<I, RV,RE>
+      S, ST,
+      E, ET,
+      T, TT,
+      RV,RE
     >
   {
-    private final RET raw;
     private final ST srcT;
     private final TT tgtT;
-    protected EdgeType(ST srcT, RET raw, TT tgtT) {
-      this.raw = raw;
+    protected EdgeType(ST srcT, TT tgtT) {
       this.srcT = srcT;
       this.tgtT = tgtT;
     }
     @Override public final ST sourceType() { return srcT; }
     @Override public final TT targetType() { return tgtT; }
-    @Override public final RET raw() { return raw; }
+    // @Override public final RET raw() { return raw; }
   }
 
   public abstract class Edge<
-    S extends TwitterGraph<I, RV,RE>.Vertex<S,ST>,
+    S  extends TwitterGraph<I, RV,RE>.Vertex<S,ST>,
     ST extends TwitterGraph<I, RV,RE>.VertexType<S,ST>,
-    E extends TwitterGraph<I, RV,RE>.Edge<S,ST,E,ET,T,TT>,
-    ET extends TwitterGraph<I, RV,RE>.EdgeType<S,ST,E,ET,T,TT>,
-    T extends TwitterGraph<I, RV,RE>.Vertex<T,TT>,
+    E  extends TwitterGraph<I, RV,RE>.Edge<S,ST, E,ET, T,TT>,
+    ET extends TwitterGraph<I, RV,RE>.EdgeType<S,ST, E,ET, T,TT>,
+    T  extends TwitterGraph<I, RV,RE>.Vertex<T,TT>,
     TT extends TwitterGraph<I, RV,RE>.VertexType<T,TT>
   >
   extends
     TwitterGraph<I,RV,RE>.Element<E,ET>
   implements
     com.bio4j.angulillos.TypedEdge<
-      S, ST, TwitterGraph<I, RV,RE>,
-      E, ET, TwitterGraph<I, RV,RE>, I, RV,RE,
-      T, TT, TwitterGraph<I, RV,RE>
+      S, ST,
+      E, ET,
+      T, TT,
+      RV,RE
     >
   {
     private final RE edge;
@@ -320,13 +309,13 @@ implements
   }
 
   public abstract class Property<
-    V extends TwitterGraph<I,RV,RE>.Element<V,VT>,
+    V  extends TwitterGraph<I,RV,RE>.Element<V,VT>,
     VT extends TwitterGraph<I,RV,RE>.ElementType<V, VT>,
-    P extends TwitterGraph<I,RV,RE>.Property<V,VT,P,PV>,
+    P  extends TwitterGraph<I,RV,RE>.Property<V,VT, P,PV>,
     PV
   >
   implements
-    com.bio4j.angulillos.Property<V,VT,P,PV,TwitterGraph<I, RV,RE>, I, RV,RE>
+    com.bio4j.angulillos.Property<V,VT, P,PV, RV,RE>
   {
     private final VT type;
     protected Property(VT type) { this.type = type; }

--- a/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
+++ b/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
@@ -5,16 +5,16 @@ import com.bio4j.angulillos.TwitterGraph.*;
 import java.util.stream.Stream;
 
 
-public abstract class TwitterGraphTestSuite<I extends UntypedGraph<V,VT,E,ET>,V,VT,E,ET> {
+public abstract class TwitterGraphTestSuite<I extends UntypedGraph<RV,RE>,RV,RE> {
 
-  protected TwitterGraph<I,V,VT,E,ET> g;
+  protected TwitterGraph<I,RV,RE> g;
 
-  public void doSomething(TwitterGraph<I,V,VT,E,ET>.User user) {
+  public void doSomething(TwitterGraph<I,RV,RE>.User user) {
 
-    Stream<TwitterGraph<I,V,VT,E,ET>.Tweet> tweets = user.outV(g.Posted());
+    Stream<TwitterGraph<I,RV,RE>.Tweet> tweets = user.outV(g.Posted());
   }
 
-  public Stream<TwitterGraph<I,V,VT,E,ET>.User> tweetedTheTweetsThatTweeted(TwitterGraph<I,V,VT,E,ET>.User user) {
+  public Stream<TwitterGraph<I,RV,RE>.User> tweetedTheTweetsThatTweeted(TwitterGraph<I,RV,RE>.User user) {
 
     return user.outV(g.Posted()).flatMap(
       tw -> tw.inV(g.Posted())
@@ -22,12 +22,12 @@ public abstract class TwitterGraphTestSuite<I extends UntypedGraph<V,VT,E,ET>,V,
   }
 
   /* This uses arity-specific methods to return **the** user that tweeted a tweet. */
-  public TwitterGraph<I,V,VT,E,ET>.User tweeted(TwitterGraph<I,V,VT,E,ET>.Tweet tweet) {
+  public TwitterGraph<I,RV,RE>.User tweeted(TwitterGraph<I,RV,RE>.Tweet tweet) {
 
     return tweet.inOneV(g.Posted());
   }
 
-  public Stream<TwitterGraph<I,V,VT,E,ET>.User> repliedToSomeTweetFrom(TwitterGraph<I,V,VT,E,ET>.User user) {
+  public Stream<TwitterGraph<I,RV,RE>.User> repliedToSomeTweetFrom(TwitterGraph<I,RV,RE>.User user) {
 
     return user
       .outV( g.Posted() )


### PR DESCRIPTION
My idea here is that if everything in the end depends only on raw vertex/edge types (`RV,RE`), then we don't need to carry around the typed `G` and untyped `I` graph type references. 

If I understand right, we don't get more type information from those particular instances of the types, instead everything in the API is based on the values of those types (i.e. every typed vertex has a reference  `TypedGraph<RV,RE> graph()` with the same `RV,RE` as the vertex itself and it's enough for all the things to work as expected).

P.S. I'm just experimenting here. I'm not sure that this will work as I expect.