### PR TITLE
Experimenting with element/its type relationship

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,4 +9,5 @@ javaVersion  := "1.8"
 
 excludeFilter in unmanagedSources :=
   (excludeFilter in unmanagedSources).value ||
+  "*Index.java" ||
   "*Query.java"

--- a/src/main/java/com/bio4j/angulillos/GraphSchema.java
+++ b/src/main/java/com/bio4j/angulillos/GraphSchema.java
@@ -19,105 +19,97 @@ public abstract class GraphSchema<
      They bound raw vertex/edge types that the graph is parametrized by.
   */
 
-  private abstract class Element<
-    F  extends     Element<F,FT, RF>,
-    FT extends ElementType<F,FT, RF>,
-    RF
-  > implements TypedElement<F,FT, SG,RF> {
+  // public abstract class ElementType<
+  //   FT extends ElementType<FT, RF>,
+  //   RF
+  // > implements com.bio4j.angulillos.ElementType<FT, SG,RF> {
+  //
+  //   // public abstract FT self();
+  //
+  //   // public <X> Property<X> property(String nameSuffix, Class<X> valueClass) {
+  //   //   return new Property<X>(nameSuffix, valueClass);
+  //   // }
+  //   //
+  //   // public class Property<X> extends com.bio4j.angulillos.Property<FT,X> {
+  //   //   private Property(String nameSuffix, Class<X> valueClass) {
+  //   //     super(self(), nameSuffix, valueClass);
+  //   //   }
+  //   // }
+  // }
 
-    @Override public final SG graph() { return GraphSchema.this.self(); }
+  // private abstract class Element<
+  //   F  extends Element<F,RF>,
+  //   RF
+  // > //extends ElementType<F,RF>
+  //   implements com.bio4j.angulillos.TypedElement<F,SG,RF> {
+  //
+  //   @Override public final SG graph() { return GraphSchema.this.self(); }
+  //
+  //   private final RF raw;
+  //   @Override public final RF raw()  { return this.raw; }
+  //
+  //   // NOTE: we cannot do the same to `self`, because `super()` constructor cannot refer to `this`
+  //   protected Element(RF raw) {
+  //     this.raw  = raw;
+  //   }
+  // }
 
-    private final RF raw;
-    private final FT type;
-
-    @Override public final RF raw()  { return this.raw; }
-    @Override public final FT type() { return this.type; }
-
-    // NOTE: we cannot do the same to `self`, because `super()` constructor cannot refer to `this`
-    protected Element(RF raw, FT type) {
-      this.raw  = raw;
-      this.type = type;
-    }
-  }
-
-  public abstract class ElementType<
-    F  extends     Element<F,FT, RF>,
-    FT extends ElementType<F,FT, RF>,
-    RF
-  > implements TypedElement.Type<F,FT, SG,RF> {
-
-    public abstract FT self();
-
-    public <X> Property<X> property(String nameSuffix, Class<X> valueClass) {
-      return new Property<X>(nameSuffix, valueClass);
-    }
-
-    public class Property<X> extends com.bio4j.angulillos.Property<FT,X> {
-      private Property(String nameSuffix, Class<X> valueClass) {
-        super(self(), nameSuffix, valueClass);
-      }
-    }
-  }
-
-
-  public abstract class Vertex<
-    V extends Vertex<V>
-  > extends Element<V, VertexType<V>, RV>
-    implements TypedVertex<V, VertexType<V>, SG,RV,RE> {
-
-    protected Vertex(RV raw, VertexType<V> type) { super(raw, type); }
-
-    // protected abstract class Type extends VertexType<V> {}
-  }
 
   public abstract class VertexType<
     V extends Vertex<V>
-  > extends ElementType<V, VertexType<V>, RV>
-    implements TypedVertex.Type<V, VertexType<V>, SG,RV,RE> {
+  > implements com.bio4j.angulillos.VertexType<V, SG,RV,RE> {
 
-    @Override public VertexType<V> self() { return this; }
+    protected VertexType() {};
+    // @Override public VertexType<V> self() { return this; }
   }
 
+  public abstract class Vertex<
+    V extends Vertex<V>
+  > extends VertexType<V>
+    implements com.bio4j.angulillos.TypedVertex<V, SG,RV,RE> {
+
+    @Override public final SG graph() { return GraphSchema.this.self(); }
+
+    private final RV raw;
+    @Override public final RV raw()  { return this.raw; }
+
+    protected Vertex(RV raw) { this.raw  = raw; }
+    // public final V fromRaw(RV raw) { this.raw  = raw; }
+  }
+
+
+  public abstract class EdgeType<
+    ST extends Vertex<ST>,
+    ET extends Edge<ST,ET,TT>,
+    TT extends Vertex<TT>
+  > implements com.bio4j.angulillos.EdgeType<ST,ET,TT, SG,RV,RE> {
+
+    private final ST sourceType;
+    private final TT targetType;
+
+    @Override public final ST sourceType() { return this.sourceType; }
+    @Override public final TT targetType() { return this.targetType; }
+
+    protected EdgeType(ST sourceType, TT targetType) {
+      this.sourceType = sourceType;
+      this.targetType = targetType;
+    }
+  }
 
   public abstract class Edge<
     S extends Vertex<S>,
     E extends Edge<S,E,T>,
     T extends Vertex<T>
-  > extends Element<E, EdgeType<S,E,T>, RE>
-    implements TypedEdge<
-      S, VertexType<S>,
-      E, EdgeType<S,E,T>,
-      T, VertexType<T>,
-      SG,RV,RE
-    > {
+  > extends EdgeType<S,E,T>
+    implements com.bio4j.angulillos.TypedEdge<S,E,T, SG,RV,RE> {
 
-    protected Edge(RE raw, EdgeType<S,E,T> type) { super(raw, type); }
-  }
+    private final RE raw;
+    @Override public final RE raw()  { return this.raw; }
 
-  public abstract class EdgeType<
-    S extends Vertex<S>,
-    E extends Edge<S,E,T>,
-    T extends Vertex<T>
-  > extends ElementType<E, EdgeType<S,E,T>, RE>
-    implements TypedEdge.Type<
-      S, VertexType<S>,
-      E, EdgeType<S,E,T>,
-      T, VertexType<T>,
-      SG,RV,RE
-  > {
-
-    private final VertexType<S> sourceType;
-    private final VertexType<T> targetType;
-
-    @Override public final VertexType<S> sourceType() { return this.sourceType; }
-    @Override public final VertexType<T> targetType() { return this.targetType; }
-
-    protected EdgeType(VertexType<S> sourceType, VertexType<T> targetType) {
-      this.sourceType = sourceType;
-      this.targetType = targetType;
+    protected Edge(S sourceType, RE raw, T targetType) {
+      super(sourceType, targetType);
+      this.raw = raw;
     }
-
-    @Override public EdgeType<S,E,T> self() { return this; }
   }
 
 }

--- a/src/main/java/com/bio4j/angulillos/GraphSchema.java
+++ b/src/main/java/com/bio4j/angulillos/GraphSchema.java
@@ -1,5 +1,7 @@
 package com.bio4j.angulillos;
 
+import java.util.function.*;
+
 
 public abstract class GraphSchema<
   SG extends GraphSchema<SG,RV,RE>,
@@ -26,15 +28,6 @@ public abstract class GraphSchema<
   //
   //   // public abstract FT self();
   //
-  //   // public <X> Property<X> property(String nameSuffix, Class<X> valueClass) {
-  //   //   return new Property<X>(nameSuffix, valueClass);
-  //   // }
-  //   //
-  //   // public class Property<X> extends com.bio4j.angulillos.Property<FT,X> {
-  //   //   private Property(String nameSuffix, Class<X> valueClass) {
-  //   //     super(self(), nameSuffix, valueClass);
-  //   //   }
-  //   // }
   // }
 
   // private abstract class Element<
@@ -74,7 +67,25 @@ public abstract class GraphSchema<
     @Override public final RV raw()  { return this.raw; }
 
     protected Vertex(RV raw) { this.raw  = raw; }
-    // public final V fromRaw(RV raw) { this.raw  = raw; }
+
+
+    public <X> Property<X> property(String nameSuffix, Class<X> valueClass) {
+      return new Property<X>(nameSuffix, valueClass);
+    }
+
+    public class Property<X> extends com.bio4j.angulillos.Property<V,X>
+    implements Supplier<X>,
+               Function<X,V> {
+
+      private Property(String nameSuffix, Class<X> valueClass) {
+        super(self(), nameSuffix, valueClass);
+      }
+
+      @Override public X get() { return self().get(this); }
+
+      public V set(X value) { return self().set(this, value); }
+      @Override public V apply(X value) { return set(value); }
+    }
   }
 
 

--- a/src/main/java/com/bio4j/angulillos/Property.java
+++ b/src/main/java/com/bio4j/angulillos/Property.java
@@ -22,20 +22,20 @@ package com.bio4j.angulillos;
 // }
 
 public class Property<
-  FT extends TypedElement.Type<?,FT,?,?>,
+  F extends TypedElement<F,?,?>,
   X
-> { //implements com.bio4j.angulillos.Property<FT,X> {
+> { //implements com.bio4j.angulillos.Property<F,X> {
 
   public  final String _label;
-  private final FT elementType;
+  private final F element;
   private final Class<X> valueClass;
 
-  public final FT elementType() { return this.elementType; }
+  public final F element() { return this.element; }
   public final Class<X> valueClass() { return this.valueClass; }
 
-  protected Property(FT elementType, String nameSuffix, Class<X> valueClass) {
-    this.elementType = elementType;
+  protected Property(F element, String nameSuffix, Class<X> valueClass) {
+    this.element = element;
     this.valueClass  = valueClass;
-    this._label = elementType()._label() + "." + nameSuffix;
+    this._label = element()._label() + "." + nameSuffix;
   }
 }

--- a/src/main/java/com/bio4j/angulillos/TypedEdge.java
+++ b/src/main/java/com/bio4j/angulillos/TypedEdge.java
@@ -1,5 +1,104 @@
 package com.bio4j.angulillos;
 
+interface HasArity {
+
+  /* the arity for this edge. This corresponds to the edge between the two vertex types. */
+  EdgeType.Arity arity();
+}
+
+interface EdgeType <
+  // source vertex
+  S extends TypedVertex<S, ?,RV,RE>,
+  // edge
+  E extends TypedEdge<S,E,T, G,RV,RE>,
+  // target vertex
+  T extends TypedVertex<T, ?,RV,RE>,
+  // graph & raws
+  G extends TypedGraph<G,RV,RE>,
+  RV,RE
+> extends
+  ElementType<E,G,RE>,
+  HasArity
+{
+
+  S sourceType();
+  T targetType();
+
+
+  /*
+    ### Arities
+
+    We have six basic arities: three for in, three for out.
+  */
+  public enum Arity {
+
+    oneToOne,
+    oneToAtMostOne,
+    oneToAtLeastOne,
+    oneToAny,
+
+    atMostOneToOne,
+    atMostOneToAtMostOne,
+    atMostOneToAtLeastOne,
+    atMostOneToAny,
+
+    atLeastOneToOne,
+    atLeastOneToAtMostOne,
+    atLeastOneToAtLeastOne,
+    atLeastOneToAny,
+
+    anyToOne,
+    anyToAtMostOne,
+    anyToAtLeastOne,
+    anyToAny;
+  }
+
+  /* #### In-arities */
+
+  /* An edge type `e` being _surjective_ implies that calling `inV(e)` will always return some, possibly several, vertices */
+  interface FromAtLeastOne extends HasArity {}
+  /* An edge type `e` being _from many_ implies that calling `inV(e)` will in general return more than one vertex */
+  interface FromOne extends HasArity {}
+  /* An edge type `e` being _from one_ implies that calling `inV(e)` will return at most one vertex */
+  interface FromAtMostOne extends HasArity {}
+
+  /* #### Out-arities */
+
+  /* That an edge type `e` being _always defined_ implies that calling `outV(e)` will always return some, possibly several, vertices */
+  interface ToAtLeastOne extends HasArity {}
+  /* An edge type `e` being _to many_ implies that calling `outV(e)` will in general return more than one vertex */
+  interface ToOne extends HasArity {}
+  /* An edge type `e` being _to one_ implies that calling `outV(e)` will return at most one vertex */
+  interface ToAtMostOne extends HasArity {}
+
+
+  /*
+    #### Arity combinations
+
+    These are all the possible combinations of the different arities. In the first line under `extends` you see those that correspond to `in`, and in the second one those that correspond to `out`
+  */
+  interface OneToOne        extends FromOne, ToOne        { default Arity arity() { return Arity.oneToOne; } }
+  interface OneToAtMostOne  extends FromOne, ToAtMostOne  { default Arity arity() { return Arity.oneToAtMostOne; } }
+  interface OneToAtLeastOne extends FromOne, ToAtLeastOne { default Arity arity() { return Arity.oneToAtLeastOne; } }
+  interface OneToAny        extends FromOne               { default Arity arity() { return Arity.oneToAny; } }
+
+  interface AtMostOneToOne        extends FromAtMostOne, ToOne        { default Arity arity() { return Arity.atMostOneToOne; } }
+  interface AtMostOneToAtMostOne  extends FromAtMostOne, ToAtMostOne  { default Arity arity() { return Arity.atMostOneToAtMostOne; } }
+  interface AtMostOneToAtLeastOne extends FromAtMostOne, ToAtLeastOne { default Arity arity() { return Arity.atMostOneToAtLeastOne; } }
+  interface AtMostOneToAny        extends FromAtMostOne               { default Arity arity() { return Arity.atMostOneToAny; } }
+
+  interface AtLeastOneToOne        extends FromAtLeastOne, ToOne        { default Arity arity() { return Arity.atLeastOneToOne; } }
+  interface AtLeastOneToAtMostOne  extends FromAtLeastOne, ToAtMostOne  { default Arity arity() { return Arity.atLeastOneToAtMostOne; } }
+  interface AtLeastOneToAtLeastOne extends FromAtLeastOne, ToAtLeastOne { default Arity arity() { return Arity.atLeastOneToAtLeastOne; } }
+  interface AtLeastOneToAny        extends FromAtLeastOne               { default Arity arity() { return Arity.atLeastOneToAny; } }
+
+  interface AnyToOne        extends ToOne        { default Arity arity() { return Arity.anyToOne; } }
+  interface AnyToAtMostOne  extends ToAtMostOne  { default Arity arity() { return Arity.anyToAtMostOne; } }
+  interface AnyToAtLeastOne extends ToAtLeastOne { default Arity arity() { return Arity.anyToAtLeastOne; } }
+  interface AnyToAny        extends HasArity     { default Arity arity() { return Arity.anyToAny; } }
+
+}
+
 /*
   ## Edges
 
@@ -10,139 +109,30 @@ package com.bio4j.angulillos;
   - `T` the target TypedVertex, `TT` the target TypedVertex type
 */
 interface TypedEdge <
-  // source vertex
-  S  extends      TypedVertex<S,ST, ?,RV,RE>,
-  ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-  // edge
-  E  extends      TypedEdge<S,ST, E,ET, T,TT, G,RV,RE>,
-  ET extends TypedEdge.Type<S,ST, E,ET, T,TT, G,RV,RE>,
-  // target vertex
-  T  extends      TypedVertex<T,TT, ?,RV,RE>,
-  TT extends TypedVertex.Type<T,TT, ?,RV,RE>,
+  S  extends TypedVertex<S, ?,RV,RE>,
+  E  extends TypedEdge<S,E,T, G,RV,RE>,
+  T  extends TypedVertex<T, ?,RV,RE>,
   // graph & raws
   G extends TypedGraph<G,RV,RE>,
   RV,RE
->
-  extends TypedElement<E,ET,G,RE>
-{
+> extends EdgeType<S,E,T, G,RV,RE>,
+          TypedElement<E,G,RE> {
 
-  /* the source vertex of this edge */
-  default S source() { return graph().source( self() ); }
-
-  /* the target vertex of this edge */
-  default T target() { return graph().target( self() ); }
-
-
-  @Override default
-  <X> X get(Property<ET,X> property) { return graph().getProperty(self(), property); }
-
-  @Override default
-  <X> E set(Property<ET,X> property, X value) {
-
-    graph().setProperty(self(), property, value);
-    return self();
-  }
+  // /* the source vertex of this edge */
+  // default S source() { return graph().source( self() ); }
+  //
+  // /* the target vertex of this edge */
+  // default T target() { return graph().target( self() ); }
 
 
-  interface HasArity {
+  // @Override default
+  // <X> X get(Property<ET,X> property) { return graph().getProperty(self(), property); }
+  //
+  // @Override default
+  // <X> E set(Property<ET,X> property, X value) {
+  //
+  //   graph().setProperty(self(), property, value);
+  //   return self();
+  // }
 
-    /* the arity for this edge. This corresponds to the edge between the two vertex types. */
-    Type.Arity arity();
-  }
-
-  interface Type <
-    // source vertex
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    // edge
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, G,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, G,RV,RE>,
-    // target vertex
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>,
-    // graph & raws
-    G extends TypedGraph<G,RV,RE>,
-    RV,RE
-  > extends
-    TypedElement.Type<E,ET,G,RE>,
-    HasArity
-  {
-
-    ST sourceType();
-    TT targetType();
-
-
-    /*
-      ### Arities
-
-      We have six basic arities: three for in, three for out.
-    */
-    public enum Arity {
-
-      oneToOne,
-      oneToAtMostOne,
-      oneToAtLeastOne,
-      oneToAny,
-
-      atMostOneToOne,
-      atMostOneToAtMostOne,
-      atMostOneToAtLeastOne,
-      atMostOneToAny,
-
-      atLeastOneToOne,
-      atLeastOneToAtMostOne,
-      atLeastOneToAtLeastOne,
-      atLeastOneToAny,
-
-      anyToOne,
-      anyToAtMostOne,
-      anyToAtLeastOne,
-      anyToAny;
-    }
-
-    /* #### In-arities */
-
-    /* An edge type `e` being _surjective_ implies that calling `inV(e)` will always return some, possibly several, vertices */
-    interface FromAtLeastOne extends HasArity {}
-    /* An edge type `e` being _from many_ implies that calling `inV(e)` will in general return more than one vertex */
-    interface FromOne extends HasArity {}
-    /* An edge type `e` being _from one_ implies that calling `inV(e)` will return at most one vertex */
-    interface FromAtMostOne extends HasArity {}
-
-    /* #### Out-arities */
-
-    /* That an edge type `e` being _always defined_ implies that calling `outV(e)` will always return some, possibly several, vertices */
-    interface ToAtLeastOne extends HasArity {}
-    /* An edge type `e` being _to many_ implies that calling `outV(e)` will in general return more than one vertex */
-    interface ToOne extends HasArity {}
-    /* An edge type `e` being _to one_ implies that calling `outV(e)` will return at most one vertex */
-    interface ToAtMostOne extends HasArity {}
-
-
-    /*
-      #### Arity combinations
-
-      These are all the possible combinations of the different arities. In the first line under `extends` you see those that correspond to `in`, and in the second one those that correspond to `out`
-    */
-    interface OneToOne        extends FromOne, ToOne        { default Arity arity() { return Arity.oneToOne; } }
-    interface OneToAtMostOne  extends FromOne, ToAtMostOne  { default Arity arity() { return Arity.oneToAtMostOne; } }
-    interface OneToAtLeastOne extends FromOne, ToAtLeastOne { default Arity arity() { return Arity.oneToAtLeastOne; } }
-    interface OneToAny        extends FromOne               { default Arity arity() { return Arity.oneToAny; } }
-
-    interface AtMostOneToOne        extends FromAtMostOne, ToOne        { default Arity arity() { return Arity.atMostOneToOne; } }
-    interface AtMostOneToAtMostOne  extends FromAtMostOne, ToAtMostOne  { default Arity arity() { return Arity.atMostOneToAtMostOne; } }
-    interface AtMostOneToAtLeastOne extends FromAtMostOne, ToAtLeastOne { default Arity arity() { return Arity.atMostOneToAtLeastOne; } }
-    interface AtMostOneToAny        extends FromAtMostOne               { default Arity arity() { return Arity.atMostOneToAny; } }
-
-    interface AtLeastOneToOne        extends FromAtLeastOne, ToOne        { default Arity arity() { return Arity.atLeastOneToOne; } }
-    interface AtLeastOneToAtMostOne  extends FromAtLeastOne, ToAtMostOne  { default Arity arity() { return Arity.atLeastOneToAtMostOne; } }
-    interface AtLeastOneToAtLeastOne extends FromAtLeastOne, ToAtLeastOne { default Arity arity() { return Arity.atLeastOneToAtLeastOne; } }
-    interface AtLeastOneToAny        extends FromAtLeastOne               { default Arity arity() { return Arity.atLeastOneToAny; } }
-
-    interface AnyToOne        extends ToOne        { default Arity arity() { return Arity.anyToOne; } }
-    interface AnyToAtMostOne  extends ToAtMostOne  { default Arity arity() { return Arity.anyToAtMostOne; } }
-    interface AnyToAtLeastOne extends ToAtLeastOne { default Arity arity() { return Arity.anyToAtLeastOne; } }
-    interface AnyToAny        extends HasArity     { default Arity arity() { return Arity.anyToAny; } }
-
-  }
 }

--- a/src/main/java/com/bio4j/angulillos/TypedElement.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElement.java
@@ -49,10 +49,10 @@ interface TypedElement <
   /* The graph in which this element lives. */
   G graph();
 
-  // /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
-  // <X> X get(Property<FT,X> property);
-  //
-  // /* `set` sets the value of a `property` for this element. Again, you can only set properties that this element has, using values of the corresponding property value type. */
-  // <X> F set(Property<FT,X> property, X value);
+  /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
+  <X> X get(Property<F,X> property);
+
+  /* `set` sets the value of a `property` for this element. Again, you can only set properties that this element has, using values of the corresponding property value type. */
+  <X> F set(Property<F,X> property, X value);
 
 }

--- a/src/main/java/com/bio4j/angulillos/TypedElement.java
+++ b/src/main/java/com/bio4j/angulillos/TypedElement.java
@@ -1,6 +1,23 @@
 package com.bio4j.angulillos;
 
 /*
+  ### Element types
+
+  Element types are also used as factories for constructing instances of the corresponding elements.
+*/
+interface ElementType <
+  F  extends TypedElement<F,G,RF>,
+  G  extends TypedGraph<G,?,?>,
+  RF
+> {
+  /* Constructs a value of the typed element of this type */
+  F fromRaw(RF rawElem);
+
+  // NOTE: this should be final, but interface cannot have final methods
+  default String _label() { return getClass().getCanonicalName(); }
+}
+
+/*
   ## Elements
 
   This is a base interface for both [Vertices](TypedVertex.java.md) and [Edges](TypedEdge.java.md); it only has that which is common to both:
@@ -14,34 +31,14 @@ package com.bio4j.angulillos;
   `E` refers to the element itself, and `ET` its type. You cannot define one without defining the other.
 */
 interface TypedElement <
-  F  extends      TypedElement<F,FT, G,RF>,
-  FT extends TypedElement.Type<F,FT, G,RF>,
+  F  extends TypedElement<F, G,RF>,
+  // FT extends TypedElement.Type<F,FT, G,RF>,
   G    extends TypedGraph<G,?,?>,
   RF
->
-{
+> extends ElementType<F,G,RF> {
 
-  /*
-    ### Element types
-
-    Element types are also used as factories for constructing instances of the corresponding elements.
-  */
-  interface Type <
-    F  extends      TypedElement<F,FT, G,RF>,
-    FT extends TypedElement.Type<F,FT, G,RF>,
-    G    extends TypedGraph<G,?,?>,
-    RF
-  > {
-    /* Constructs a value of the typed element of this type */
-    F fromRaw(RF rawElem);
-
-    // NOTE: this should be final, but interface cannot have final methods
-    default String _label() { return getClass().getCanonicalName(); }
-  }
-
-
-  /* The type of this element */
-  FT type();
+  // /* The type of this element */
+  // FT type();
 
   /* An abstract reference to the instance of the implementing class. This should return `this` in all cases; it just cannot be implemented at this level. */
   F self();
@@ -52,10 +49,10 @@ interface TypedElement <
   /* The graph in which this element lives. */
   G graph();
 
-  /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
-  <X> X get(Property<FT,X> property);
-
-  /* `set` sets the value of a `property` for this element. Again, you can only set properties that this element has, using values of the corresponding property value type. */
-  <X> F set(Property<FT,X> property, X value);
+  // /* The `get` method lets you get the value of a `property` which this element has. For that, you pass as an argument the [property](Property.java.md). Note that the type bounds only allow properties of this element. */
+  // <X> X get(Property<FT,X> property);
+  //
+  // /* `set` sets the value of a `property` for this element. Again, you can only set properties that this element has, using values of the corresponding property value type. */
+  // <X> F set(Property<FT,X> property, X value);
 
 }

--- a/src/main/java/com/bio4j/angulillos/TypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/TypedGraph.java
@@ -19,316 +19,316 @@ interface TypedGraph <
 
   UntypedGraph<RV,RE> raw();
 
-  default <
-    V  extends      TypedVertex<V,VT, G,RV,RE>,
-    VT extends TypedVertex.Type<V,VT, G,RV,RE>
-  >
-  V addVertex(VT vertexType) {
-
-    return vertexType.fromRaw(
-      raw().addVertex( vertexType._label() )
-    );
-  }
-
-  /* adds an edge; note that this method does not set any properties. As it needs to be called by vertices in possibly different graphs, all the graph bounds are free with respect to G. */
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  E addEdge(S from, ET edgeType, T to) {
-
-    return edgeType.fromRaw(
-      raw().addEdge( from.raw(), edgeType._label(), to.raw() )
-    );
-  }
+  // default <
+  //   V  extends      TypedVertex<V,VT, G,RV,RE>,
+  //   VT extends TypedVertex.Type<V,VT, G,RV,RE>
+  // >
+  // V addVertex(VT vertexType) {
+  //
+  //   return vertexType.fromRaw(
+  //     raw().addVertex( vertexType._label() )
+  //   );
+  // }
+  //
+  // /* adds an edge; note that this method does not set any properties. As it needs to be called by vertices in possibly different graphs, all the graph bounds are free with respect to G. */
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // E addEdge(S from, ET edgeType, T to) {
+  //
+  //   return edgeType.fromRaw(
+  //     raw().addEdge( from.raw(), edgeType._label(), to.raw() )
+  //   );
+  // }
 
   /*
     ### properties
       foobarbuh
     These methods are used for setting and getting properties on vertices and edges.
   */
-  default <
-    V  extends      TypedVertex<V,VT, G,RV,RE>,
-    VT extends TypedVertex.Type<V,VT, G,RV,RE>,
-    X
-  >
-  X getProperty(V vertex, Property<VT,X> property) {
-
-    return raw().<X>getPropertyV(vertex.raw(), property._label);
-  }
-
-  /* Get the value of a property from an edge of G. */
-  default <
-    E  extends      TypedEdge<?,?, E,ET, ?,?, G,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, ?,?, G,RV,RE>,
-    X
-  >
-  X getProperty(E edge, Property<ET,X> property) {
-
-    return raw().<X>getPropertyE(edge.raw(), property._label);
-  }
-
-  /* Sets the value of a property for a vertex of G. */
-  default <
-    V  extends      TypedVertex<V,VT, G,RV,RE>,
-    VT extends TypedVertex.Type<V,VT, G,RV,RE>,
-    X
-  >
-  G setProperty(V vertex, Property<VT,X> property, X value) {
-
-    raw().setPropertyV(vertex.raw(), property._label, value);
-    return vertex.graph();
-  }
-
-  /* Sets the value of a property for an edge of G. */
-  default <
-    E  extends      TypedEdge<?,?, E,ET, ?,?, G,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, ?,?, G,RV,RE>,
-    X
-  >
-  G setProperty(E edge, Property<ET,X> property, X value) {
-
-    raw().setPropertyE(edge.raw(), property._label, value);
-    return edge.graph();
-  }
+  // default <
+  //   V  extends      TypedVertex<V,VT, G,RV,RE>,
+  //   VT extends TypedVertex.Type<V,VT, G,RV,RE>,
+  //   X
+  // >
+  // X getProperty(V vertex, Property<VT,X> property) {
+  //
+  //   return raw().<X>getPropertyV(vertex.raw(), property._label);
+  // }
+  //
+  // /* Get the value of a property from an edge of G. */
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, ?,?, G,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, ?,?, G,RV,RE>,
+  //   X
+  // >
+  // X getProperty(E edge, Property<ET,X> property) {
+  //
+  //   return raw().<X>getPropertyE(edge.raw(), property._label);
+  // }
+  //
+  // /* Sets the value of a property for a vertex of G. */
+  // default <
+  //   V  extends      TypedVertex<V,VT, G,RV,RE>,
+  //   VT extends TypedVertex.Type<V,VT, G,RV,RE>,
+  //   X
+  // >
+  // G setProperty(V vertex, Property<VT,X> property, X value) {
+  //
+  //   raw().setPropertyV(vertex.raw(), property._label, value);
+  //   return vertex.graph();
+  // }
+  //
+  // /* Sets the value of a property for an edge of G. */
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, ?,?, G,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, ?,?, G,RV,RE>,
+  //   X
+  // >
+  // G setProperty(E edge, Property<ET,X> property, X value) {
+  //
+  //   raw().setPropertyE(edge.raw(), property._label, value);
+  //   return edge.graph();
+  // }
 
   /*
     ### source and target
 
     gets the source of an edge of G, which could be of a different graph.
   */
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, ?,?, G,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, ?,?, G,RV,RE>
-  >
-  S source(E edge) {
-
-    return edge.type().sourceType().fromRaw(
-      raw().source(edge.raw())
-    );
-  }
-
-  default <
-    E  extends      TypedEdge<?,?, E,ET, T,TT, G,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, T,TT, G,RV,RE>,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  T target(E edge) {
-
-    return edge.type().targetType().fromRaw(
-      raw().target(edge.raw())
-    );
-  }
-
-
-  /* #### Outgoing edges */
-  default <
-    S  extends      TypedVertex<S,ST,G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST,G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
-  >
-  Stream<E> outE(S source, ET edgeType) {
-
-    return raw().outE(
-      source.raw(),
-      edgeType._label()
-    ).map(
-      edgeType::fromRaw
-    );
-  }
-
-  default <
-    S  extends      TypedVertex<S,ST, G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
-             & TypedEdge.Type.ToAtLeastOne
-  >
-  Stream<E> outAtLeastOneE(S source, ET edgeType) {
-
-    return outE(source, edgeType);
-  }
-
-  default <
-    S  extends      TypedVertex<S,ST, G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
-             & TypedEdge.Type.ToAtMostOne
-  >
-  Optional<E> outAtMostOneE(S source, ET edgeType) {
-
-    return outE(source, edgeType).findFirst();
-  }
-
-  default <
-    S  extends      TypedVertex<S,ST, G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
-             & TypedEdge.Type.ToOne
-  >
-  E outOneE(S source, ET edgeType) {
-
-    return outE(source, edgeType).findFirst().get();
-  }
-
-  /* #### Incoming edges */
-  default <
-    E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>,
-    T  extends      TypedVertex<T,TT,G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT,G,RV,RE>
-  >
-  Stream<E> inE(T vertex, ET edgeType) {
-
-    return raw().inE(
-      vertex.raw(),
-      edgeType._label()
-    ).map(
-      edgeType::fromRaw
-    );
-  }
-
-  default <
-    E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.FromAtLeastOne,
-    T  extends      TypedVertex<T,TT, G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, G,RV,RE>
-  >
-  Stream<E> inAtLeastOneE(T target, ET edgeType) { return inE(target, edgeType); }
-
-  default <
-    E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.FromAtMostOne,
-    T  extends      TypedVertex<T,TT, G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, G,RV,RE>
-  >
-  Optional<E> inAtMostOneE(T target, ET edgeType) { return inE(target, edgeType).findFirst(); }
-
-  default <
-    E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.FromOne,
-    T  extends      TypedVertex<T,TT, G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, G,RV,RE>
-  >
-  E inOneE(T target, ET edgeType) { return inE(target, edgeType).findFirst().get(); }
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, ?,?, G,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, ?,?, G,RV,RE>
+  // >
+  // S source(E edge) {
+  //
+  //   return edge.type().sourceType().fromRaw(
+  //     raw().source(edge.raw())
+  //   );
+  // }
+  //
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, T,TT, G,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, T,TT, G,RV,RE>,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // T target(E edge) {
+  //
+  //   return edge.type().targetType().fromRaw(
+  //     raw().target(edge.raw())
+  //   );
+  // }
 
 
-  /* #### Outgoing vertices */
-  default <
-    S  extends      TypedVertex<S,ST, G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  Stream<T> outV(S source, ET edgeType) {
-
-    return raw().outV(
-      source.raw(),
-      edgeType._label()
-    ).map(
-      edgeType.targetType()::fromRaw
-    );
-  }
-
-  default <
-    S  extends      TypedVertex<S,ST, G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.ToAtLeastOne,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  Stream<T> outAtLeastOneV(S source, ET edgeType) { return outV(source, edgeType); }
-
-  default <
-    S  extends      TypedVertex<S,ST, G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.ToAtMostOne,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  Optional<T> outAtMostOneV(S source, ET edgeType) { return outV(source, edgeType).findFirst(); }
-
-  default <
-    S  extends      TypedVertex<S,ST, G,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, G,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.ToOne,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  T outOneV(S source, ET edgeType) { return outV(source, edgeType).findFirst().get(); }
-
-
-  /* #### Incoming vertices */
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>,
-    T  extends      TypedVertex<T,TT, G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, G,RV,RE>
-  >
-  Stream<S> inV(T target, ET edgeType) {
-
-    return raw().inV(
-      target.raw(),
-      edgeType._label()
-    ).map(
-      edgeType.sourceType()::fromRaw
-    );
-  }
-
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.FromAtLeastOne,
-    T  extends      TypedVertex<T,TT, G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, G,RV,RE>
-  >
-  Stream<S> inAtLeastOneV(T target, ET edgeType) { return inV(target, edgeType); }
-
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.FromAtMostOne,
-    T  extends      TypedVertex<T,TT, G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, G,RV,RE>
-  >
-  Optional<S> inAtMostOneV(T target, ET edgeType) { return inV(target, edgeType).findFirst(); }
-
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.FromOne,
-    T  extends      TypedVertex<T,TT, G,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, G,RV,RE>
-  >
-  S inOneV(T target, ET edgeType) { return inV(target, edgeType).findFirst().get(); }
+  // /* #### Outgoing edges */
+  // default <
+  //   S  extends      TypedVertex<S,ST,G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST,G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
+  // >
+  // Stream<E> outE(S source, ET edgeType) {
+  //
+  //   return raw().outE(
+  //     source.raw(),
+  //     edgeType._label()
+  //   ).map(
+  //     edgeType::fromRaw
+  //   );
+  // }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtLeastOne
+  // >
+  // Stream<E> outAtLeastOneE(S source, ET edgeType) {
+  //
+  //   return outE(source, edgeType);
+  // }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtMostOne
+  // >
+  // Optional<E> outAtMostOneE(S source, ET edgeType) {
+  //
+  //   return outE(source, edgeType).findFirst();
+  // }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, ?,?, ?,RV,RE>
+  //            & TypedEdge.Type.ToOne
+  // >
+  // E outOneE(S source, ET edgeType) {
+  //
+  //   return outE(source, edgeType).findFirst().get();
+  // }
+  //
+  // /* #### Incoming edges */
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>,
+  //   T  extends      TypedVertex<T,TT,G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT,G,RV,RE>
+  // >
+  // Stream<E> inE(T vertex, ET edgeType) {
+  //
+  //   return raw().inE(
+  //     vertex.raw(),
+  //     edgeType._label()
+  //   ).map(
+  //     edgeType::fromRaw
+  //   );
+  // }
+  //
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtLeastOne,
+  //   T  extends      TypedVertex<T,TT, G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, G,RV,RE>
+  // >
+  // Stream<E> inAtLeastOneE(T target, ET edgeType) { return inE(target, edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtMostOne,
+  //   T  extends      TypedVertex<T,TT, G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, G,RV,RE>
+  // >
+  // Optional<E> inAtMostOneE(T target, ET edgeType) { return inE(target, edgeType).findFirst(); }
+  //
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.FromOne,
+  //   T  extends      TypedVertex<T,TT, G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, G,RV,RE>
+  // >
+  // E inOneE(T target, ET edgeType) { return inE(target, edgeType).findFirst().get(); }
+  //
+  //
+  // /* #### Outgoing vertices */
+  // default <
+  //   S  extends      TypedVertex<S,ST, G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // Stream<T> outV(S source, ET edgeType) {
+  //
+  //   return raw().outV(
+  //     source.raw(),
+  //     edgeType._label()
+  //   ).map(
+  //     edgeType.targetType()::fromRaw
+  //   );
+  // }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtLeastOne,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // Stream<T> outAtLeastOneV(S source, ET edgeType) { return outV(source, edgeType); }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtMostOne,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // Optional<T> outAtMostOneV(S source, ET edgeType) { return outV(source, edgeType).findFirst(); }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, G,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, G,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.ToOne,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // T outOneV(S source, ET edgeType) { return outV(source, edgeType).findFirst().get(); }
+  //
+  //
+  // /* #### Incoming vertices */
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   T  extends      TypedVertex<T,TT, G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, G,RV,RE>
+  // >
+  // Stream<S> inV(T target, ET edgeType) {
+  //
+  //   return raw().inV(
+  //     target.raw(),
+  //     edgeType._label()
+  //   ).map(
+  //     edgeType.sourceType()::fromRaw
+  //   );
+  // }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtLeastOne,
+  //   T  extends      TypedVertex<T,TT, G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, G,RV,RE>
+  // >
+  // Stream<S> inAtLeastOneV(T target, ET edgeType) { return inV(target, edgeType); }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtMostOne,
+  //   T  extends      TypedVertex<T,TT, G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, G,RV,RE>
+  // >
+  // Optional<S> inAtMostOneV(T target, ET edgeType) { return inV(target, edgeType).findFirst(); }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.FromOne,
+  //   T  extends      TypedVertex<T,TT, G,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, G,RV,RE>
+  // >
+  // S inOneV(T target, ET edgeType) { return inV(target, edgeType).findFirst().get(); }
 
 }

--- a/src/main/java/com/bio4j/angulillos/TypedGraph.java
+++ b/src/main/java/com/bio4j/angulillos/TypedGraph.java
@@ -51,50 +51,46 @@ interface TypedGraph <
       foobarbuh
     These methods are used for setting and getting properties on vertices and edges.
   */
-  // default <
-  //   V  extends      TypedVertex<V,VT, G,RV,RE>,
-  //   VT extends TypedVertex.Type<V,VT, G,RV,RE>,
-  //   X
-  // >
-  // X getProperty(V vertex, Property<VT,X> property) {
-  //
-  //   return raw().<X>getPropertyV(vertex.raw(), property._label);
-  // }
-  //
-  // /* Get the value of a property from an edge of G. */
-  // default <
-  //   E  extends      TypedEdge<?,?, E,ET, ?,?, G,RV,RE>,
-  //   ET extends TypedEdge.Type<?,?, E,ET, ?,?, G,RV,RE>,
-  //   X
-  // >
-  // X getProperty(E edge, Property<ET,X> property) {
-  //
-  //   return raw().<X>getPropertyE(edge.raw(), property._label);
-  // }
-  //
-  // /* Sets the value of a property for a vertex of G. */
-  // default <
-  //   V  extends      TypedVertex<V,VT, G,RV,RE>,
-  //   VT extends TypedVertex.Type<V,VT, G,RV,RE>,
-  //   X
-  // >
-  // G setProperty(V vertex, Property<VT,X> property, X value) {
-  //
-  //   raw().setPropertyV(vertex.raw(), property._label, value);
-  //   return vertex.graph();
-  // }
-  //
-  // /* Sets the value of a property for an edge of G. */
-  // default <
-  //   E  extends      TypedEdge<?,?, E,ET, ?,?, G,RV,RE>,
-  //   ET extends TypedEdge.Type<?,?, E,ET, ?,?, G,RV,RE>,
-  //   X
-  // >
-  // G setProperty(E edge, Property<ET,X> property, X value) {
-  //
-  //   raw().setPropertyE(edge.raw(), property._label, value);
-  //   return edge.graph();
-  // }
+  default <
+    V  extends TypedVertex<V, G,RV,RE>,
+    X
+  >
+  X getProperty(V vertex, Property<V,X> property) {
+
+    return raw().<X>getPropertyV(vertex.raw(), property._label);
+  }
+
+  /* Get the value of a property from an edge of G. */
+  default <
+    E  extends TypedEdge<?,E,?, G,RV,RE>,
+    X
+  >
+  X getProperty(E edge, Property<E,X> property) {
+
+    return raw().<X>getPropertyE(edge.raw(), property._label);
+  }
+
+  /* Sets the value of a property for a vertex of G. */
+  default <
+    V  extends TypedVertex<V, G,RV,RE>,
+    X
+  >
+  G setProperty(V vertex, Property<V,X> property, X value) {
+
+    raw().setPropertyV(vertex.raw(), property._label, value);
+    return vertex.graph();
+  }
+
+  /* Sets the value of a property for an edge of G. */
+  default <
+    E  extends TypedEdge<?,E,?, G,RV,RE>,
+    X
+  >
+  G setProperty(E edge, Property<E,X> property, X value) {
+
+    raw().setPropertyE(edge.raw(), property._label, value);
+    return edge.graph();
+  }
 
   /*
     ### source and target

--- a/src/main/java/com/bio4j/angulillos/TypedVertex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertex.java
@@ -3,6 +3,11 @@ package com.bio4j.angulillos;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+interface VertexType <
+  V extends TypedVertex<V,G,RV,RE>,
+  G  extends TypedGraph<G,RV,RE>,
+  RV,RE
+> extends ElementType<V,G,RV> {}
 
 /*
   ## Typed Vertices
@@ -10,55 +15,45 @@ import java.util.stream.Stream;
   A typed vertex. A vertex and its type need to be defined at the same time. The vertex keeps a reference of its type, while the type works as a factory for creating vertices with that type.
 */
 interface TypedVertex <
-  V  extends      TypedVertex<V,VT, G,RV,RE>,
-  VT extends TypedVertex.Type<V,VT, G,RV,RE>,
+  V  extends TypedVertex<V, G,RV,RE>,
   G  extends TypedGraph<G,RV,RE>,
   RV,RE
->
-  extends TypedElement<V,VT,G,RV>
-{
+> extends VertexType<V,G,RV,RE>,
+        TypedElement<V,G,RV> {
 
-  interface Type <
-    V  extends      TypedVertex<V,VT, G,RV,RE>,
-    VT extends TypedVertex.Type<V,VT, G,RV,RE>,
-    G  extends TypedGraph<G,RV,RE>,
-    RV,RE
-  > extends TypedElement.Type<V,VT,G,RV> {}
-
-
-  /*
-    ### Create edges in/out of this vertex
-
-    There are two methods for creating new edges, into and out of this vertex respectively. Their implementation delegates to the typed graph methods. Note that all graphs are in principle different.
-  */
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
-  >
-  E addInEdge(S from, ET edgeType) { return graph().addEdge( from, edgeType, self() ); }
-
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  E addOutEdge(ET edgeType, T to) { return graph().addEdge( self(), edgeType, to ); }
+  // /*
+  //   ### Create edges in/out of this vertex
+  //
+  //   There are two methods for creating new edges, into and out of this vertex respectively. Their implementation delegates to the typed graph methods. Note that all graphs are in principle different.
+  // */
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
+  // >
+  // E addInEdge(S from, ET edgeType) { return graph().addEdge( from, edgeType, self() ); }
+  //
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // E addOutEdge(ET edgeType, T to) { return graph().addEdge( self(), edgeType, to ); }
 
 
-  /* ### Properties */
-  @Override default
-  <X> X get(Property<VT,X> property) { return graph().getProperty(self(), property); }
-
-
-  @Override default
-  <X> V set(Property<VT,X> property, X value) {
-
-    graph().setProperty(self(), property, value);
-    return self();
-  }
+  // /* ### Properties */
+  // @Override default
+  // <X> X get(Property<VT,X> property) { return graph().getProperty(self(), property); }
+  //
+  //
+  // @Override default
+  // <X> V set(Property<VT,X> property, X value) {
+  //
+  //   graph().setProperty(self(), property, value);
+  //   return self();
+  // }
 
   /*
     ### Getting incoming and outgoing edges
@@ -66,137 +61,137 @@ interface TypedVertex <
     For when you don't know anything about the arity, we have unbounded in/out methods which return `Stream`s
   */
 
-  /* #### outE */
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
-  >
-  Stream<E> outE(ET edgeType) { return graph().outE(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
-             & TypedEdge.Type.ToAtLeastOne
-  >
-  Stream<E> outAtLeastOneE(ET edgeType) { return graph().outAtLeastOneE(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
-             & TypedEdge.Type.ToAtMostOne
-  >
-  Optional<E> outAtMostOneE(ET edgeType) { return graph().outAtMostOneE(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
-             & TypedEdge.Type.ToOne
-  >
-  E outOneE(ET edgeType) { return graph().outOneE(self(), edgeType); }
-
-
-  /* #### inE */
-  default <
-    E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
-  >
-  Stream<E> inE(ET edgeType) { return graph().inE(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
-             & TypedEdge.Type.FromAtLeastOne
-  >
-  Stream<E> inAtLeastOneE(ET edgeType) { return graph().inAtLeastOneE(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
-             & TypedEdge.Type.FromAtMostOne
-  >
-  Optional<E> inAtMostOneE(ET edgeType) { return graph().inAtMostOneE(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
-             & TypedEdge.Type.FromOne
-  >
-  E inOneE(ET edgeType) { return graph().inOneE(self(), edgeType); }
-
-  /////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-  /* #### outV */
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  Stream<T> outV(ET edgeType) { return graph().outV(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.ToAtLeastOne,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  Stream<T> outAtLeastOneV(ET edgeType) { return graph().outAtLeastOneV(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.ToAtMostOne,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  Optional<T> outAtMostOneV(ET edgeType) { return graph().outAtMostOneV(self(), edgeType); }
-
-  default <
-    E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
-    ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>
-             & TypedEdge.Type.ToOne,
-    T  extends      TypedVertex<T,TT, ?,RV,RE>,
-    TT extends TypedVertex.Type<T,TT, ?,RV,RE>
-  >
-  T outOneV(ET edgeType) { return graph().outOneV(self(), edgeType); }
-
-
-  /* #### inV */
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
-  >
-  Stream<S> inV(ET edgeType) { return graph().inV(self(), edgeType); }
-
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
-             & TypedEdge.Type.FromAtLeastOne
-  >
-  Stream<S> inAtLeastOneV(ET edgeType) { return graph().inAtLeastOneV(self(), edgeType); }
-
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
-             & TypedEdge.Type.FromAtMostOne
-  >
-  Optional<S> inAtMostOneV(ET edgeType) { return graph().inAtMostOneV(self(), edgeType); }
-
-  default <
-    S  extends      TypedVertex<S,ST, ?,RV,RE>,
-    ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
-    E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
-    ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
-             & TypedEdge.Type.FromOne
-  >
-  S inOneV(ET edgeType) { return graph().inOneV(self(), edgeType); }
+  // /* #### outE */
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
+  // >
+  // Stream<E> outE(ET edgeType) { return graph().outE(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtLeastOne
+  // >
+  // Stream<E> outAtLeastOneE(ET edgeType) { return graph().outAtLeastOneE(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtMostOne
+  // >
+  // Optional<E> outAtMostOneE(ET edgeType) { return graph().outAtMostOneE(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, ?,?, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, ?,?, ?,RV,RE>
+  //            & TypedEdge.Type.ToOne
+  // >
+  // E outOneE(ET edgeType) { return graph().outOneE(self(), edgeType); }
+  //
+  //
+  // /* #### inE */
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
+  // >
+  // Stream<E> inE(ET edgeType) { return graph().inE(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtLeastOne
+  // >
+  // Stream<E> inAtLeastOneE(ET edgeType) { return graph().inAtLeastOneE(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtMostOne
+  // >
+  // Optional<E> inAtMostOneE(ET edgeType) { return graph().inAtMostOneE(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<?,?, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<?,?, E,ET, V,VT, ?,RV,RE>
+  //            & TypedEdge.Type.FromOne
+  // >
+  // E inOneE(ET edgeType) { return graph().inOneE(self(), edgeType); }
+  //
+  // /////////////////////////////////////////////////////////////////////////////////////////////////////
+  //
+  //
+  // /* #### outV */
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // Stream<T> outV(ET edgeType) { return graph().outV(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtLeastOne,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // Stream<T> outAtLeastOneV(ET edgeType) { return graph().outAtLeastOneV(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.ToAtMostOne,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // Optional<T> outAtMostOneV(ET edgeType) { return graph().outAtMostOneV(self(), edgeType); }
+  //
+  // default <
+  //   E  extends      TypedEdge<V,VT, E,ET, T,TT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<V,VT, E,ET, T,TT, ?,RV,RE>
+  //            & TypedEdge.Type.ToOne,
+  //   T  extends      TypedVertex<T,TT, ?,RV,RE>,
+  //   TT extends TypedVertex.Type<T,TT, ?,RV,RE>
+  // >
+  // T outOneV(ET edgeType) { return graph().outOneV(self(), edgeType); }
+  //
+  //
+  // /* #### inV */
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
+  // >
+  // Stream<S> inV(ET edgeType) { return graph().inV(self(), edgeType); }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtLeastOne
+  // >
+  // Stream<S> inAtLeastOneV(ET edgeType) { return graph().inAtLeastOneV(self(), edgeType); }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
+  //            & TypedEdge.Type.FromAtMostOne
+  // >
+  // Optional<S> inAtMostOneV(ET edgeType) { return graph().inAtMostOneV(self(), edgeType); }
+  //
+  // default <
+  //   S  extends      TypedVertex<S,ST, ?,RV,RE>,
+  //   ST extends TypedVertex.Type<S,ST, ?,RV,RE>,
+  //   E  extends      TypedEdge<S,ST, E,ET, V,VT, ?,RV,RE>,
+  //   ET extends TypedEdge.Type<S,ST, E,ET, V,VT, ?,RV,RE>
+  //            & TypedEdge.Type.FromOne
+  // >
+  // S inOneV(ET edgeType) { return graph().inOneV(self(), edgeType); }
 
 }

--- a/src/main/java/com/bio4j/angulillos/TypedVertex.java
+++ b/src/main/java/com/bio4j/angulillos/TypedVertex.java
@@ -44,16 +44,16 @@ interface TypedVertex <
 
 
   // /* ### Properties */
-  // @Override default
-  // <X> X get(Property<VT,X> property) { return graph().getProperty(self(), property); }
-  //
-  //
-  // @Override default
-  // <X> V set(Property<VT,X> property, X value) {
-  //
-  //   graph().setProperty(self(), property, value);
-  //   return self();
-  // }
+  @Override default
+  <X> X get(Property<V,X> property) { return graph().getProperty(self(), property); }
+
+
+  @Override default
+  <X> V set(Property<V,X> property, X value) {
+
+    graph().setProperty(self(), property, value);
+    return self();
+  }
 
   /*
     ### Getting incoming and outgoing edges

--- a/src/test/java/com/bio4j/angulillos/Twitter.java
+++ b/src/test/java/com/bio4j/angulillos/Twitter.java
@@ -18,6 +18,8 @@ extends
     private User(RV raw) { super(raw); }
     @Override public final User fromRaw(RV raw) { return new User(raw); }
 
+    public final Property<String> name = property("name", String.class);
+    public final Property<Integer> age = property("age", Integer.class);
   }
 
   public final VertexType<User> user = new User(null);
@@ -26,12 +28,6 @@ extends
   // NOTE: although we initialized raw with null, it's not accessible:
   // RV nope = user.raw;
   // RV neither = user.raw();
-
-  // public final class UserType extends VertexType<User> {
-  //
-  //   public final Property<String> name = property("name", String.class);
-  //   public final Property<Integer> age = property("age", Integer.class);
-  // }
 
 
   // public final class Tweet extends Vertex<Tweet> {

--- a/src/test/java/com/bio4j/angulillos/Twitter.java
+++ b/src/test/java/com/bio4j/angulillos/Twitter.java
@@ -1,6 +1,5 @@
 package com.bio4j.angulillos;
 
-import com.bio4j.angulillos.TypedEdge.Type.*;
 import java.net.URL;
 import java.util.Date;
 
@@ -15,70 +14,70 @@ extends
   /* ### Vertices and their types */
 
   public final class User extends Vertex<User> {
-    @Override public final User self() { return this; } private User(RV raw) { super(raw, user); }
-
-    // public class Type extends Vertex<User>.Type {
-    //   // @Override public User fromRaw(RV raw) { return new User().withRaw(raw); } //   @Override public User fromRaw(RV raw) { return new User(raw); }
-    //
-    //   public final Property<String> name = property("name", String.class);
-    //   public final Property<Integer> age = property("age", Integer.class);
-    // }
-  }
-  // public final User.Type user = new User(null).new Type();
-
-  public final UserType user = new UserType();
-  public final class UserType extends VertexType<User> {
+    @Override public final User self() { return this; }
+    private User(RV raw) { super(raw); }
     @Override public final User fromRaw(RV raw) { return new User(raw); }
 
-    public final Property<String> name = property("name", String.class);
-    public final Property<Integer> age = property("age", Integer.class);
   }
 
+  public final VertexType<User> user = new User(null);
+  // public final User user(RV raw) { return new User(raw); }
 
-  public final class Tweet extends Vertex<Tweet> {
-    @Override public final Tweet self() { return this; }
-    private Tweet(RV raw) { super(raw, tweet); }
-  }
+  // NOTE: although we initialized raw with null, it's not accessible:
+  // RV nope = user.raw;
+  // RV neither = user.raw();
 
-  public final TweetType tweet = new TweetType();
-  public final class TweetType extends VertexType<Tweet> {
-    @Override public final Tweet fromRaw(RV raw) { return new Tweet(raw); }
-
-    public final Property<String> text = property("text", String.class);
-    public final Property<URL>    url  = property("url",  URL.class);
-  }
-
-
-  /* ### Edges and their types */
-
-  public final class Follows extends Edge<User, Follows, User> {
-    @Override public final Follows self() { return this; }
-    private Follows(RE raw) { super(raw, follows); }
-  }
-
-  public final FollowsType follows = new FollowsType();
-  public final class FollowsType extends EdgeType<User, Follows, User>
-  implements AnyToAny {
-    @Override public final Follows fromRaw(RE raw) { return new Follows(raw); }
-    private FollowsType() { super(user, user); }
-
-    public final Property<Date> since = property("since", Date.class);
-  }
+  // public final class UserType extends VertexType<User> {
+  //
+  //   public final Property<String> name = property("name", String.class);
+  //   public final Property<Integer> age = property("age", Integer.class);
+  // }
 
 
-  public final class Posted extends Edge<User, Posted, Tweet> {
-    @Override public final Posted self() { return this; }
-    private Posted(RE raw) { super(raw, posted); }
-  }
-
-  // Any tweet is posted by exactly one user, but user may post any number of tweets (incl. 0)
-  public final PostedType posted = new PostedType();
-  public final class PostedType extends EdgeType<User, Posted, Tweet>
-  implements OneToAny {
-    @Override public final Posted fromRaw(RE raw) { return new Posted(raw); }
-    private PostedType() { super(user, tweet); }
-
-    public final Property<Date> date = property("date", Date.class);
-  }
+  // public final class Tweet extends Vertex<Tweet> {
+  //   @Override public final Tweet self() { return this; }
+  //   private Tweet(RV raw) { super(raw, tweet); }
+  // }
+  //
+  // public final TweetType tweet = new TweetType();
+  // public final class TweetType extends VertexType<Tweet> {
+  //   @Override public final Tweet fromRaw(RV raw) { return new Tweet(raw); }
+  //
+  //   public final Property<String> text = property("text", String.class);
+  //   public final Property<URL>    url  = property("url",  URL.class);
+  // }
+  //
+  //
+  // /* ### Edges and their types */
+  //
+  // public final class Follows extends Edge<User, Follows, User> {
+  //   @Override public final Follows self() { return this; }
+  //   private Follows(RE raw) { super(raw, follows); }
+  // }
+  //
+  // public final FollowsType follows = new FollowsType();
+  // public final class FollowsType extends EdgeType<User, Follows, User>
+  // implements AnyToAny {
+  //   @Override public final Follows fromRaw(RE raw) { return new Follows(raw); }
+  //   private FollowsType() { super(user, user); }
+  //
+  //   public final Property<Date> since = property("since", Date.class);
+  // }
+  //
+  //
+  // public final class Posted extends Edge<User, Posted, Tweet> {
+  //   @Override public final Posted self() { return this; }
+  //   private Posted(RE raw) { super(raw, posted); }
+  // }
+  //
+  // // Any tweet is posted by exactly one user, but user may post any number of tweets (incl. 0)
+  // public final PostedType posted = new PostedType();
+  // public final class PostedType extends EdgeType<User, Posted, Tweet>
+  // implements OneToAny {
+  //   @Override public final Posted fromRaw(RE raw) { return new Posted(raw); }
+  //   private PostedType() { super(user, tweet); }
+  //
+  //   public final Property<Date> date = property("date", Date.class);
+  // }
 
 }

--- a/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
+++ b/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
@@ -11,12 +11,13 @@ public abstract class TwitterGraphTestSuite<RV,RE> {
 
   // Trying to use some API and see that it returns correct type without any conversions:
   Twitter<RV,RE>.User u =
-    g.user.fromRaw(null);
-      // .set(g.user.name, "Bob")
-      // .set(g.user.age, 42);
+    g.user.fromRaw(null)
+      .name.set("Bob")
+      .age.set(42);
 
-  // String name = u.get(g.user.name);
-  //
+  String name = u.name.get();
+  Integer age = u.age.get();
+
   // Twitter<RV,RE>.Tweet t =
   //   g.tweet.fromRaw(null)
   //     .set(g.tweet.text, "blah-bluh");

--- a/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
+++ b/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
@@ -11,29 +11,29 @@ public abstract class TwitterGraphTestSuite<RV,RE> {
 
   // Trying to use some API and see that it returns correct type without any conversions:
   Twitter<RV,RE>.User u =
-    g.user.fromRaw(null)
-      .set(g.user.name, "Bob")
-      .set(g.user.age, 42);
+    g.user.fromRaw(null);
+      // .set(g.user.name, "Bob")
+      // .set(g.user.age, 42);
 
-  String name = u.get(g.user.name);
-
-  Twitter<RV,RE>.Tweet t =
-    g.tweet.fromRaw(null)
-      .set(g.tweet.text, "blah-bluh");
+  // String name = u.get(g.user.name);
+  //
+  // Twitter<RV,RE>.Tweet t =
+  //   g.tweet.fromRaw(null)
+  //     .set(g.tweet.text, "blah-bluh");
 
   //////////////////////////////////////////
 
   // Examples with edges:
 
-  Twitter<RV,RE>.Posted p =
-    g.posted.fromRaw(null)
-      .set(g.posted.date, null);
-
-  Twitter<RV,RE>.User poster = p.source();
-
-  Stream<Twitter<RV,RE>.Follows> fe = u.outE(g.follows);
-
-  Stream<Twitter<RV,RE>.Tweet> ts = u.outV(g.posted);
+  // Twitter<RV,RE>.Posted p =
+  //   g.posted.fromRaw(null)
+  //     .set(g.posted.date, null);
+  //
+  // Twitter<RV,RE>.User poster = p.source();
+  //
+  // Stream<Twitter<RV,RE>.Follows> fe = u.outE(g.follows);
+  //
+  // Stream<Twitter<RV,RE>.Tweet> ts = u.outV(g.posted);
 
   // public void doSomething(Twitter<RV,RE>.User user) {
   //


### PR DESCRIPTION
The idea here:
- `ElementType` type is just a holder for the unique label and a factory for creating `TypedElement`s
- `TypedElement` _extends_ it. It holds the `raw` value and add all those graph API methods.

It comes from the idea that in the end we want just the `User` type for working with its values and the `VertexType` value `user` to refer to it as `User`s factory and the properties holder.

In the end I'm not sure this idea work well. It does simplify some things, but doesn't improve the things much and you still need to write some boilerplate when defining `User`: `self()`, `fromRaw()` and the constructor.
