### PR TITLE
Fix naming conventions for types in tests

### DIFF
--- a/src/test/java/com/bio4j/angulillos/Twitter.java
+++ b/src/test/java/com/bio4j/angulillos/Twitter.java
@@ -14,24 +14,6 @@ extends
 
   public Twitter(UntypedGraph<RV,RE> raw) { super(raw); }
 
-  // public abstract class Vertex<
-  //   V extends Vertex<V>
-  // > extends TypedGraph<Twitter<RV,RE>, RV,RE>.Vertex<V> {
-  //
-  //   protected Vertex(RV raw, VertexType<V> type) { super(raw, type); }
-  //
-  //   // experimenting with override:
-  //   @Override public <
-  //     E  extends      TypedEdge<V,VertexType<V>, E,ET, ?,?, ?,RV,RE>,
-  //     ET extends TypedEdge.Type<V,VertexType<V>, E,ET, ?,?, ?,RV,RE>
-  //   >
-  //   Stream<E> outE(ET edgeType) {
-  //     System.out.println("This is overriden Twitter-graph specific outE");
-  //     return outE(edgeType);
-  //   }
-  // }
-
-
   /* ### Vertices and their types */
 
   public final class User extends Vertex<User> {
@@ -43,17 +25,16 @@ extends
   public final class UserType extends VertexType<User> {
     public final User fromRaw(RV raw) { return new User(raw); }
 
-    public final name name = new name();
-    public final class name extends Property<String> implements FromAny, ToOne {
-      private name() { super(String.class); }
+    public final Name name = new Name();
+    public final class Name extends Property<String> implements FromAny, ToOne {
+      private Name() { super(String.class); }
     }
 
-    public final age age = new age();
-    public final class age extends Property<Integer> implements FromAny, ToOne {
-      private age() { super(Integer.class); }
+    public final Age age = new Age();
+    public final class Age extends Property<Integer> implements FromAny, ToOne {
+      private Age() { super(Integer.class); }
     }
   }
-
 
   public final class Tweet extends Vertex<Tweet> {
     @Override public final Tweet self() { return this; }
@@ -64,19 +45,19 @@ extends
   public final class TweetType extends VertexType<Tweet> {
     public final Tweet fromRaw(RV raw) { return new Tweet(raw); }
 
-    public final text text = new text();
-    public final class text extends Property<String> implements FromAny, ToOne {
-      private text() { super(String.class); }
+    public final Text text = new Text();
+    public final class Text extends Property<String> implements FromAny, ToOne {
+      private Text() { super(String.class); }
     }
 
-    public final url url = new url();
-    public final class url extends Property<URL> implements FromAtMostOne, ToOne {
-      private url() { super(URL.class); }
+    public final Url url = new Url();
+    public final class Url extends Property<URL> implements FromAtMostOne, ToOne {
+      private Url() { super(URL.class); }
     }
 
-    public final byUrl byUrl = new byUrl();
-    public final class byUrl extends UniqueIndex<url,URL> {
-      private byUrl() { super(url); }
+    public final ByUrl byUrl = new ByUrl();
+    public final class ByUrl extends UniqueIndex<Url,URL> {
+      private ByUrl() { super(url); }
     }
     // NOTE: Try to uncomment it and instantiate TwitterSchema
     // public final text text2 = new text();
@@ -99,12 +80,11 @@ extends
     private FollowsType() { super(user, user); }
     public final Follows fromRaw(RE raw) { return new Follows(raw); }
 
-    public final since since = new since();
-    public final class since extends Property<Date> implements FromAny, ToOne {
-      private since() { super(Date.class); }
+    public final Since since = new Since();
+    public final class Since extends Property<Date> implements FromAny, ToOne {
+      private Since() { super(Date.class); }
     }
   }
-
 
   public final class Posted extends Edge<User, Posted, Tweet> {
     @Override public final Posted self() { return this; }
@@ -118,9 +98,9 @@ extends
     private PostedType() { super(user, tweet); }
     public final Posted fromRaw(RE raw) { return new Posted(raw); }
 
-    public final when when = new when();
-    public final class when extends Property<Date> implements FromAny, ToOne {
-      private when() { super(Date.class); }
+    public final When when = new When();
+    public final class When extends Property<Date> implements FromAny, ToOne {
+      private When() { super(Date.class); }
     }
   }
 

--- a/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
+++ b/src/test/java/com/bio4j/angulillos/TwitterGraphTestSuite.java
@@ -28,18 +28,15 @@ public abstract class TwitterGraphTestSuite<RV,RE> {
   //////////////////////////////////////////
 
   // Examples with edges:
-
   public final Twitter<RV,RE>.Posted p =
     g.posted.fromRaw(null)
       .set(g.posted.when, null);
 
   public final Twitter<RV,RE>.User poster = p.source();
 
-
   public final Stream<Twitter<RV,RE>.Follows> fe = u.outE(g.follows);
 
   public final Stream<Date> dates = fe.map(edge -> edge.get(g.follows.since));
-
 
   public final Stream<Twitter<RV,RE>.Tweet> ts = u.outV(g.posted);
 
@@ -47,50 +44,16 @@ public abstract class TwitterGraphTestSuite<RV,RE> {
 
   public final Optional<Twitter<RV,RE>.Tweet> fromURL(URL url) { return g.tweet.byUrl.find(url); }
 
-  // to print the schema:
+  public Stream<Twitter<RV,RE>.User> tweetedTheTweetsThatTweeted(Twitter<RV,RE>.User user) {
 
-  // g.vertexTypes.foreach { vt =>
-  //   println(s"""${vt._label}:
-  //     |  properties: ${vt.properties().map(_._label())}
-  //     |  inEdges: ${vt.inEdges().map{ _._label() }}
-  //     |  outEdges: ${vt.outEdges().map{ _._label() }}""".stripMargin
-  //     )
-  // }
-  //
-  // g.edgeTypes.foreach { et =>
-  //   println(s"""${et._label}:
-  //     |  properties: ${et.properties().map(_._label())}
-  //     |  source: ${et.source()._label()}
-  //     |  target: ${et.target()._label()}""".stripMargin
-  //     )
-  // }
+    return user.outV(g.posted).flatMap(
+      tw -> tw.inV(g.posted)
+    );
+  }
 
-  // public void doSomething(Twitter<RV,RE>.User user) {
-  //
-  //   Stream<Twitter<RV,RE>.Tweet> tweets = user.outV(g.posted);
-  // }
-  //
-  // public Stream<Twitter<RV,RE>.User> tweetedTheTweetsThatTweeted(Twitter<RV,RE>.User user) {
-  //
-  //   return user.outV(g.posted).flatMap(
-  //     tw -> tw.inV(g.posted)
-  //   );
-  // }
-  //
-
-  // see #78
   /* This uses arity-specific methods to return **the** user that tweeted a tweet. */
   public Twitter<RV,RE>.User tweeted(Twitter<RV,RE>.Tweet tweet) {
 
     return tweet.inOneV(g.posted);
   }
-  //
-  // public Stream<Twitter<RV,RE>.User> repliedToSomeTweetFrom(Twitter<RV,RE>.User user) {
-  //
-  //   return user
-  //     .outV( g.posted )
-  //     .flatMap( tw -> tw.inV( g.RepliesTo() ) )
-  //     .map( tw -> tw.inOneV( g.posted ) )
-  //     .distinct();
-  // }
 }


### PR DESCRIPTION
Having classes and fields with the same name can lead to subtle errors in client code.